### PR TITLE
Add stub Fathom JSWindowActorChild.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ ID
 /.clang_complete
 /machrc
 /.machrc
+.python-version
 
 # Empty marker file that's generated when we check out NSS
 security/manager/.nss.checkout

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["FathomChild"];
+
+// Example for importing a Fathom module:
+// ChromeUtils.defineModuleGetter(
+//   this,
+//   "Fathom",
+//   "resource://gre/modules/Fathom.jsm"
+// );
+
+class FathomChild extends JSWindowActorChild {
+  constructor() {
+    super();
+  }
+
+  handleEvent(aEvent) {
+    switch (aEvent.type) {
+      case "DOMContentLoaded":
+        this.executeFathom();
+        break;
+    }
+  }
+
+  executeFathom() {
+    // TODO: Something like Fathom.runRuleset(this.document);
+    console.log(this.contentWindow.location.href);
+  }
+}

--- a/browser/actors/moz.build
+++ b/browser/actors/moz.build
@@ -35,6 +35,7 @@ FINAL_TARGET_FILES.actors += [
     'ContextMenuParent.jsm',
     'DOMFullscreenChild.jsm',
     'DOMFullscreenParent.jsm',
+    'FathomChild.jsm',
     'FormValidationChild.jsm',
     'FormValidationParent.jsm',
     'LightweightThemeChild.jsm',

--- a/browser/components/BrowserGlue.jsm
+++ b/browser/components/BrowserGlue.jsm
@@ -106,6 +106,17 @@ let ACTORS = {
     allFrames: true,
   },
 
+  Fathom: {
+    child: {
+      matches: ["*://*/*"], // See MatchPattern.webidl.
+      moduleURI: "resource:///actors/FathomChild.jsm",
+      group: "browsers", // TODO: Do we need this?
+      events: {
+        DOMContentLoaded: {},
+      },
+    },
+  },
+
   FormValidation: {
     parent: {
       moduleURI: "resource:///actors/FormValidationParent.jsm",


### PR DESCRIPTION
Edit: I marked this as a draft, as it seems the actor is being loaded on `about:*` pages as well. I will investigate.

This actor, 'FathomChild', loads after 'DOMContentLoaded' on http(s):// pages and logs 'window.location' to the Browser Console.

This works without a 'FathomParent' actor, so it looks like we can avoid setting that up in the parent process and avoid any IPC for now.

References:
* [Fission docs](https://firefox-source-docs.mozilla.org/dom/Fission.html)
* [Artifact builds docs](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Artifact_builds)