### PR TITLE
Execute rulesets on pages and add border and label

### DIFF
--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -30,20 +30,564 @@ class FathomChild extends JSWindowActorChild {
     }
   }
 
-  executeFathom() {
-    const {dom, rule, ruleset, score, type, utils: {inlineTextLength}} = fathom;
-    console.log(this.contentWindow.location.href);
+  caselessIncludes(haystack, needle) {
+    return haystack.toLowerCase().includes(needle.toLowerCase());
+  }
 
-    // An example ruleset that hits some public and private utils, just to
-    // prove it's all there:
-    const rules = ruleset([
-      rule(dom("p"), type("paragraphish")),
-      rule(type("paragraphish"), score(fnode => inlineTextLength(fnode.element))),
-      rule(type("paragraphish"), "p")
-    ]);
-    // The actual number emitted is always 1 or close to it due to the sigmoid
-    // math. It'll throw an error on pages with no <p> tags.
-    console.log(rules.against(this.document).get("p")[0].scoreFor("paragraphish"));
+  numberOfOccurrencesOf(fnode, text) {
+    const regex = new RegExp(text, "gi");
+    return (fnode.element.innerText.match(regex) || []).length;
+  }
+
+  numberOfCartOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "cart") > 1;
+  }
+
+  numberOfBuyOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "buy") > 1;
+  }
+
+  numberOfCheckoutOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "checkout") > 1;
+  }
+
+  numberOfBuyButtons(fnode) {
+    const buttons = Array.from(fnode.element.querySelectorAll('button,input,a'));
+    return buttons.filter(button => this.caselessIncludes(button.innerText, 'buy')).length > 2;
+  }
+
+  numberOfShopButtons(fnode) {
+    const buttons = Array.from(fnode.element.querySelectorAll('button,input,a'));
+    return buttons.filter(button => this.caselessIncludes(button.innerText, 'shop')).length > 2;
+  }
+
+  hasAddToCartButton(fnode) {
+    const buttons = Array.from(fnode.element.querySelectorAll('button, a[class*="btn"]'));
+    if (buttons.some(button => {
+      return this.caselessIncludes(button.innerText, 'add to cart') ||
+        this.caselessIncludes(button.innerText, 'add to bag') ||
+        this.caselessIncludes(button.innerText, 'add to basket') ||
+        this.caselessIncludes(button.innerText, 'add to trolley') ||
+        this.caselessIncludes(button.className, 'add-to-cart') ||
+        this.caselessIncludes(button.title, 'add to cart');
+    })) {
+      return true;
+    }
+    const images = Array.from(fnode.element.querySelectorAll('img'));
+    if (images.some(image => this.caselessIncludes(image.title, 'add to cart'))) {
+      return true;
+    }
+    const inputs = Array.from(fnode.element.querySelectorAll('input'));
+    if (inputs.some(input => this.caselessIncludes(input.className, 'add-to-cart'))) {
+      return true;
+    }
+    const spans = Array.from(fnode.element.querySelectorAll('span'));
+    if (spans.some(span => {
+      return this.caselessIncludes(span.className, 'addtocart') ||
+        this.caselessIncludes(span.innerText, 'add to bag') ||
+        this.caselessIncludes(span.innerText, 'add to cart');
+    })) {
+      return true;
+    }
+    const links = Array.from(fnode.element.querySelectorAll('a'));
+    return links.some(link => this.caselessIncludes(link.innerText, '加入购物车'));
+  }
+
+  hasCheckoutButton(fnode) {
+    const divs = Array.from(fnode.element.querySelectorAll('div'));
+    if (divs.some(div => this.caselessIncludes(div.className, 'checkout'))) {
+      return true;
+    }
+    const buttons = Array.from(fnode.element.querySelectorAll('button'));
+    if (buttons.some(button => {
+      return this.caselessIncludes(button.innerText, 'checkout') ||
+        this.caselessIncludes(button.innerText, 'check out') ||
+        this.caselessIncludes(button.className, 'checkout');
+    })) {
+      return true;
+    }
+    const spans = Array.from(fnode.element.querySelectorAll('span'));
+    if (spans.some(span => this.caselessIncludes(span.className, 'checkout'))) {
+      return true;
+    }
+    const links = Array.from(fnode.element.querySelectorAll('a'));
+    if (links.some(link => {
+      return this.caselessIncludes(link.innerText, 'checkout') ||
+        this.caselessIncludes(link.href, 'checkout');
+    })) {
+      return true;
+    }
+    const inputs = Array.from(fnode.element.querySelectorAll('input'));
+    return inputs.some(input => this.caselessIncludes(input.value, 'checkout'));
+  }
+
+  hasLinkToCart(fnode) {
+    const links = Array.from(fnode.element.getElementsByTagName('a'));
+    if (links.some(link => {
+      return this.caselessIncludes(link.className, 'cart') ||
+        link.href.endsWith('/cart/') ||
+        link.href.endsWith('/cart') ||
+        this.caselessIncludes(this.getAriaLabel(link), 'cart') ||
+        link.href.endsWith('/main_view_cart.php') ||
+        this.caselessIncludes(link.className, '/cart/') ||
+        link.href.endsWith('/cart.php') ||
+        link.href.endsWith('/shoppingCart') ||
+        link.href.endsWith('/ShoppingCart') ||
+        link.href.endsWith('/shopping_cart.php') ||
+        this.caselessIncludes(link.id, 'cart') ||
+        this.caselessIncludes(link.id, 'basket') ||
+        this.caselessIncludes(link.id, 'bag') ||
+        this.caselessIncludes(link.id, 'trolley') ||
+        this.caselessIncludes(link.className, 'basket') ||
+        this.caselessIncludes(link.className, 'trolley') ||
+        this.caselessIncludes(link.className, 'shoppingbag') ||
+        this.caselessIncludes(link.title, 'cart') ||
+        link.href.endsWith('/trolley') ||
+        link.href.endsWith('/basket') ||
+        link.href.endsWith('/bag') ||
+        link.href.endsWith('/viewcart') ||
+        link.href.endsWith('/basket.html') ||
+        link.href.endsWith('/ShoppingBag.aspx') ||
+        link.href.startsWith('https://cart.');
+    })) {
+      return true;
+    }
+    const buttons = Array.from(fnode.element.querySelectorAll('button'));
+    if (buttons.some(button => {
+      return this.caselessIncludes(button.className, 'cart') ||
+        this.caselessIncludes(this.getAriaLabel(button), 'cart');
+    })) {
+      return true;
+    }
+    const spans = Array.from(fnode.element.getElementsByTagName('span'));
+    return spans.some(span => {
+      return this.caselessIncludes(span.className, 'cart');
+    });
+  }
+
+  getAriaLabel(element) {
+    if (element.hasAttribute('aria-label')) {
+      return element.getAttribute('aria-label');
+    }
+    return '';
+  }
+
+  numberOfLinksToStore(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => {
+      return link.href.startsWith('https://shop.') ||
+        link.href.startsWith('https://store.') ||
+        link.href.startsWith('https://products.') ||
+        link.href.endsWith('/shop/') ||
+        link.href.endsWith('/products') ||
+        this.caselessIncludes(link.href, '/marketplace/') ||
+        this.caselessIncludes(link.href, '/store/') ||
+        this.caselessIncludes(link.href, '/shop/') ||
+        link.href.endsWith('/store');
+    }).length > 2;
+  }
+
+  numberOfLinksToCatalog(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => this.caselessIncludes(link.href, 'catalog')).length > 1;
+  }
+
+  hasShoppingCartIcon(fnode) {
+    const icons = Array.from(fnode.element.getElementsByTagName('i'));
+    if (icons.some(icon => this.caselessIncludes(icon.className, 'cart'))) {
+      return true
+    }
+    const imgs = Array.from(fnode.element.getElementsByTagName('img'));
+    if (imgs.some(img => this.caselessIncludes(img.src, 'cart'))) {
+      return true
+    }
+    const spans = Array.from(fnode.element.getElementsByTagName('span'));
+    return spans.some(span => {
+      return this.caselessIncludes(span.className, 'cart') ||
+        this.caselessIncludes(span.className, 'trolley');
+    })
+  }
+
+  hasStarRatings(fnode) {
+    const divs = Array.from(fnode.element.querySelectorAll('div[class*="rating" i], div[class*="review" i]'));
+    return divs.some(div => {
+      const stars = div.querySelectorAll('span[class*="star" i], i[class*="star" i], div[type*="star" i], div[class*="star" i], svg[class*="star" i]');
+      return stars.length >= 5;
+    });
+  }
+
+  numberOfCurrencySymbols(fnode) {
+    const currencies = /[$£€¥]/g;
+    return (fnode.element.innerText.match(currencies) || []).length >= 4;
+  }
+
+  numberOfShippingAddressOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "shipping address") >= 1;
+  }
+
+  numberOfBillingAddressOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "billing address") >= 2;
+  }
+
+  numberOfPaymentMethodOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "payment method") >= 1;
+  }
+
+  numberOfShippingMethodOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "shipping method") >= 1;
+  }
+
+  numberOfStockPhraseOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "in stock") + this.numberOfOccurrencesOf(fnode, "out of stock") >= 1;
+  }
+
+  numberOfContinueShoppingOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "continue shopping") >= 1;
+  }
+
+  numberOfPolicyOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "policy") >= 1;
+  }
+
+  numberOfTermsOccurrences(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "terms") >= 1;
+  }
+
+  numberOfLinksToSale(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => {
+      return this.caselessIncludes(link.href, 'sale') ||
+        this.caselessIncludes(link.href, 'deals') ||
+        this.caselessIncludes(link.href, 'clearance');
+    }).length >= 1;
+  }
+
+  numberOfProductLinks(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => this.caselessIncludes(link.href, 'product')).length >= 5;
+  }
+
+  numberOfElementsWithProductClass(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[class*="product" i]')).length >= 4;
+  }
+
+  numberOfElementsWithProductId(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[id*="product" i]')).length >= 1;
+  }
+
+  hasOrderForm(fnode) {
+    const forms = Array.from(fnode.element.getElementsByTagName('form'));
+    return forms.some(form => {
+      return this.caselessIncludes(form.name, 'order') ||
+        this.caselessIncludes(form.name, 'shipping') ||
+        this.caselessIncludes(form.name, 'payment') ||
+        this.caselessIncludes(form.name, 'checkout') ||
+        this.caselessIncludes(form.name, 'address') ||
+        this.caselessIncludes(form.name, 'product');
+    })
+  }
+
+  hasContactForm(fnode) {
+    const forms = Array.from(fnode.element.getElementsByTagName('form'));
+    return forms.some(form => {
+      return this.caselessIncludes(form.name, 'contact') ||
+        this.caselessIncludes(form.name, 'question');
+    })
+  }
+
+  numberOfHelpOrSupportLinks(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => {
+      try {
+        const url = new URL(link.href);
+        return this.urlIsHelpOrSupport(url)
+      } catch (e) {
+        // None empty strings that are not valid URLs
+        return false
+      }
+    }).length >= 1;
+  }
+
+  numberOfPromoLinkOccurrences(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => this.caselessIncludes(link.href, 'promo')).length >= 2;
+  }
+
+  numberOfPercentOff(fnode) {
+    return this.numberOfOccurrencesOf(fnode, "% off") >= 1;
+  }
+
+  isAHelpOrSupportURL(fnode) {
+    const pageURL = new URL(fnode.element.ownerDocument.URL);
+    return this.urlIsHelpOrSupport(pageURL);
+  }
+
+  urlIsHelpOrSupport(url) {
+    const domainPieces = url.hostname.split(".");
+    const subdomain = domainPieces[0];
+    if (this.caselessIncludes(subdomain, 'help') || this.caselessIncludes(subdomain, 'support')) {
+      return true;
+    }
+    const topLevelDomain = domainPieces[domainPieces.length - 1];
+    if (this.caselessIncludes(topLevelDomain, 'help') || this.caselessIncludes(topLevelDomain, 'support')) {
+      return true;
+    }
+    const pathname = url.pathname;
+    return (
+      this.caselessIncludes(pathname, 'help') ||
+      this.caselessIncludes(pathname, 'support') ||
+      this.caselessIncludes(pathname, 'contact') ||
+      this.caselessIncludes(pathname, 'policy') ||
+      this.caselessIncludes(pathname, 'terms') ||
+      this.caselessIncludes(pathname, 'troubleshooting')
+    );
+  }
+
+  isAJobsURL(fnode) {
+    const pageURL = new URL(fnode.element.ownerDocument.URL);
+    const domainPieces = pageURL.hostname.split(".");
+    const subdomain = domainPieces[0];
+    if (this.caselessIncludes(subdomain, 'jobs') || this.caselessIncludes(subdomain, 'careers')) {
+      return true;
+    }
+    const topLevelDomain = domainPieces[domainPieces.length - 1];
+    if (this.caselessIncludes(topLevelDomain, 'jobs') || this.caselessIncludes(topLevelDomain, 'careers')) {
+      return true;
+    }
+    const pathname = pageURL.pathname;
+    return (
+      this.caselessIncludes(pathname, 'jobs') ||
+      this.caselessIncludes(pathname, 'careers')
+    );
+  }
+
+  isAShopishURL(fnode) {
+    const pageURL = new URL(fnode.element.ownerDocument.URL);
+    const domainPieces = pageURL.hostname.split(".");
+    const subdomain = domainPieces[0];
+    if (this.caselessIncludes(subdomain, 'shop') || this.caselessIncludes(subdomain, 'store')) {
+      return true;
+    }
+    const topLevelDomain = domainPieces[domainPieces.length - 1];
+    if (this.caselessIncludes(topLevelDomain, 'shop') || this.caselessIncludes(topLevelDomain, 'store')) {
+      return true;
+    }
+    const pathname = pageURL.pathname;
+    return (
+      this.caselessIncludes(pathname, 'product') ||
+      this.caselessIncludes(pathname, 'store') ||
+      this.caselessIncludes(pathname, 'marketplace') ||
+      this.caselessIncludes(pathname, 'catalog') ||
+      this.caselessIncludes(pathname, 'shop')
+    );
+  }
+
+  // TODO: Should this just be part of `isAShopishURL`?
+  isAShoppingActionURL(fnode) {
+    const pageURL = new URL(fnode.element.ownerDocument.URL);
+    const pathname = pageURL.pathname;
+    return (
+      this.caselessIncludes(pathname, 'cart') ||
+      this.caselessIncludes(pathname, 'checkout') ||
+      this.caselessIncludes(pathname, 'wishlist') ||
+      this.caselessIncludes(pathname, 'deals') ||
+      this.caselessIncludes(pathname, 'sales') ||
+      this.caselessIncludes(pathname, 'pricing') ||
+      this.caselessIncludes(pathname, 'basket') ||
+      this.caselessIncludes(pathname, 'wish-list')
+    );
+  }
+
+  isArticleishURL(fnode) {
+    const pageURL = new URL(fnode.element.ownerDocument.URL);
+    return this.isArticleish(pageURL)
+  }
+
+  isArticleish(url) {
+    const domainPieces = url.hostname.split(".");
+    const subdomain = domainPieces[0];
+    if (this.caselessIncludes(subdomain, 'blog') || this.caselessIncludes(subdomain, 'news')) {
+      return true;
+    }
+    const topLevelDomain = domainPieces[domainPieces.length - 1];
+    if (this.caselessIncludes(topLevelDomain, 'blog') || this.caselessIncludes(topLevelDomain, 'news')) {
+      return true;
+    }
+    const pathname = url.pathname;
+    return (
+      this.caselessIncludes(pathname, 'blog') ||
+      this.caselessIncludes(pathname, 'news')
+    );
+  }
+
+  numberOfArticleishLinks(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.filter(link => {
+      try {
+        const pageURL = new URL(link.href);
+        return this.isArticleish(pageURL)
+      } catch (e) {
+        // None empty strings that are not valid URLs
+        return false
+      }
+    }).length >= 1;
+  }
+
+  hasLinkToStoreFinder(fnode) {
+    const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
+    return links.some(link => {
+      return this.caselessIncludes(link.href, 'storelocator') ||
+        this.caselessIncludes(link.href, 'storefinder') ||
+        this.caselessIncludes(link.innerText, 'store locator') ||
+        this.caselessIncludes(link.innerText, 'store finder') ||
+        this.caselessIncludes(link.innerText, 'locate a store') ||
+        this.caselessIncludes(link.innerText, 'find a store');
+    })
+  }
+
+  numberOfPrices(fnode) {
+    const price = /\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2})/g;
+    return (fnode.element.innerText.match(price) || []).length >= 5;
+  }
+
+  numberOfElementsWithCheckoutClass(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[class*="checkout" i]')).length >= 1;
+  }
+
+  numberOfElementsWithCheckoutId(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[id*="checkout" i]')).length >= 1;
+  }
+
+  numberOfElementsWithCartClass(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[class*="cart" i]')).length >= 1;
+  }
+
+  numberOfElementsWithCartId(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[id*="cart" i]')).length >= 1;
+  }
+
+  numberOfElementsWithShippingClass(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[class*="shipping" i]')).length >= 1;
+  }
+
+  numberOfElementsWithShippingId(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[id*="shipping" i]')).length >= 1;
+  }
+
+  numberOfElementsWithPaymentClass(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[class*="payment" i]')).length >= 1;
+  }
+
+  numberOfElementsWithPaymentId(fnode) {
+    return Array.from(fnode.element.querySelectorAll('*[id*="payment" i]')).length >= 1;
+  }
+
+  executeFathom() {
+    const {dom, rule, ruleset, score, type} = fathom;
+    const shoppingRules = ruleset(
+      [
+        rule(dom('html'), type('shopping')),
+        rule(type('shopping'), score(this.numberOfCartOccurrences.bind(this)), {name: 'numberOfCartOccurrences'}),
+        rule(type('shopping'), score(this.numberOfBuyOccurrences.bind(this)), {name: 'numberOfBuyOccurrences'}),
+        rule(type('shopping'), score(this.numberOfCheckoutOccurrences.bind(this)), {name: 'numberOfCheckoutOccurrences'}),
+        rule(type('shopping'), score(this.numberOfBuyButtons.bind(this)), {name: 'numberOfBuyButtons'}),
+        rule(type('shopping'), score(this.numberOfShopButtons.bind(this)), {name: 'numberOfShopButtons'}),
+        rule(type('shopping'), score(this.hasAddToCartButton.bind(this)), {name: 'hasAddToCartButton'}),
+        rule(type('shopping'), score(this.hasCheckoutButton.bind(this)), {name: 'hasCheckoutButton'}),
+        rule(type('shopping'), score(this.hasLinkToCart.bind(this)), {name: 'hasLinkToCart'}),
+        rule(type('shopping'), score(this.numberOfLinksToStore.bind(this)), {name: 'numberOfLinksToStore'}),
+        rule(type('shopping'), score(this.numberOfLinksToCatalog.bind(this)), {name: 'numberOfLinksToCatalog'}),
+        rule(type('shopping'), score(this.hasShoppingCartIcon.bind(this)), {name: 'hasShoppingCartIcon'}),
+        rule(type('shopping'), score(this.hasStarRatings.bind(this)), {name: 'hasStarRatings'}),
+        rule(type('shopping'), score(this.numberOfCurrencySymbols.bind(this)), {name: 'numberOfCurrencySymbols'}),
+        rule(type('shopping'), score(this.numberOfShippingAddressOccurrences.bind(this)), {name: 'numberOfShippingAddressOccurrences'}),
+        rule(type('shopping'), score(this.numberOfBillingAddressOccurrences.bind(this)), {name: 'numberOfBillingAddressOccurrences'}),
+        rule(type('shopping'), score(this.numberOfPaymentMethodOccurrences.bind(this)), {name: 'numberOfPaymentMethodOccurrences'}),
+        rule(type('shopping'), score(this.numberOfShippingMethodOccurrences.bind(this)), {name: 'numberOfShippingMethodOccurrences'}),
+        rule(type('shopping'), score(this.numberOfStockPhraseOccurrences.bind(this)), {name: 'numberOfStockPhraseOccurrences'}),
+        rule(type('shopping'), score(this.numberOfContinueShoppingOccurrences.bind(this)), {name: 'numberOfContinueShoppingOccurrences'}),
+        rule(type('shopping'), score(this.numberOfPolicyOccurrences.bind(this)), {name: 'numberOfPolicyOccurrences'}),
+        rule(type('shopping'), score(this.numberOfTermsOccurrences.bind(this)), {name: 'numberOfTermsOccurrences'}),
+        rule(type('shopping'), score(this.numberOfLinksToSale.bind(this)), {name: 'numberOfLinksToSale'}),
+        rule(type('shopping'), score(this.numberOfProductLinks.bind(this)), {name: 'numberOfProductLinks'}),
+        rule(type('shopping'), score(this.numberOfElementsWithProductClass.bind(this)), {name: 'numberOfElementsWithProductClass'}),
+        rule(type('shopping'), score(this.numberOfElementsWithProductId.bind(this)), {name: 'numberOfElementsWithProductId'}),
+        rule(type('shopping'), score(this.hasOrderForm.bind(this)), {name: 'hasOrderForm'}),
+        rule(type('shopping'), score(this.hasContactForm.bind(this)), {name: 'hasContactForm'}),
+        rule(type('shopping'), score(this.numberOfHelpOrSupportLinks.bind(this)), {name: 'numberOfHelpOrSupportLinks'}),
+        rule(type('shopping'), score(this.numberOfPromoLinkOccurrences.bind(this)), {name: 'numberOfPromoLinkOccurrences'}),
+        rule(type('shopping'), score(this.numberOfPercentOff.bind(this)), {name: 'numberOfPercentOff'}),
+        rule(type('shopping'), score(this.isAHelpOrSupportURL.bind(this)), {name: 'isAHelpOrSupportURL'}),
+        rule(type('shopping'), score(this.isAJobsURL.bind(this)), {name: 'isAJobsURL'}),
+        rule(type('shopping'), score(this.isAShopishURL.bind(this)), {name: 'isAShopishURL'}),
+        rule(type('shopping'), score(this.isAShoppingActionURL.bind(this)), {name: 'isAShoppingActionURL'}),
+        rule(type('shopping'), score(this.isArticleishURL.bind(this)), {name: 'isArticleishURL'}),
+        rule(type('shopping'), score(this.numberOfArticleishLinks.bind(this)), {name: 'numberOfArticleishLinks'}),
+        rule(type('shopping'), score(this.hasLinkToStoreFinder.bind(this)), {name: 'hasLinkToStoreFinder'}),
+        rule(type('shopping'), score(this.numberOfPrices.bind(this)), {name: 'numberOfPrices'}),
+        rule(type('shopping'), score(this.numberOfElementsWithCheckoutClass.bind(this)), {name: 'numberOfElementsWithCheckoutClass'}),
+        rule(type('shopping'), score(this.numberOfElementsWithCheckoutId.bind(this)), {name: 'numberOfElementsWithCheckoutId'}),
+        rule(type('shopping'), score(this.numberOfElementsWithCartClass.bind(this)), {name: 'numberOfElementsWithCartClass'}),
+        rule(type('shopping'), score(this.numberOfElementsWithCartId.bind(this)), {name: 'numberOfElementsWithCartId'}),
+        rule(type('shopping'), score(this.numberOfElementsWithShippingClass.bind(this)), {name: 'numberOfElementsWithShippingClass'}),
+        rule(type('shopping'), score(this.numberOfElementsWithShippingId.bind(this)), {name: 'numberOfElementsWithShippingId'}),
+        rule(type('shopping'), score(this.numberOfElementsWithPaymentClass.bind(this)), {name: 'numberOfElementsWithPaymentClass'}),
+        rule(type('shopping'), score(this.numberOfElementsWithPaymentId.bind(this)), {name: 'numberOfElementsWithPaymentId'}),
+        rule(type('shopping'), 'shopping')
+      ],
+      [
+        ["numberOfCartOccurrences", 0.004431677050888538],
+        ["numberOfBuyOccurrences", 0.37095534801483154],
+        ["numberOfCheckoutOccurrences", 0.003904791548848152],
+        ["numberOfBuyButtons", 0.5181145071983337],
+        ["numberOfShopButtons", 0.09862659871578217],
+        ["hasAddToCartButton", 0.5496213436126709],
+        ["hasCheckoutButton", 0.41033145785331726],
+        ["hasLinkToCart", 0.37247663736343384],
+        ["numberOfLinksToStore", 0.6745859980583191],
+        ["numberOfLinksToCatalog", 0.39251187443733215],
+        ["hasShoppingCartIcon", 0.34280550479888916],
+        ["hasStarRatings", 0.5168086886405945],
+        ["numberOfCurrencySymbols", 0.7948866486549377],
+        ["numberOfShippingAddressOccurrences", 0.8619705438613892],
+        ["numberOfBillingAddressOccurrences", 0.3214116096496582],
+        ["numberOfPaymentMethodOccurrences", -0.26714643836021423],
+        ["numberOfShippingMethodOccurrences", 0.3138491213321686],
+        ["numberOfStockPhraseOccurrences", 0.5305109620094299],
+        ["numberOfContinueShoppingOccurrences", 0.8661705255508423],
+        ["numberOfPolicyOccurrences", -0.014949105679988861],
+        ["numberOfTermsOccurrences", -0.5102343559265137],
+        ["numberOfLinksToSale", 0.6466160416603088],
+        ["numberOfProductLinks", 0.5545489192008972],
+        ["numberOfElementsWithProductClass", 0.5344703197479248],
+        ["numberOfElementsWithProductId", 0.3443285822868347],
+        ["hasOrderForm", 0.7178601026535034],
+        ["hasContactForm", -1.2140718698501587],
+        ["numberOfHelpOrSupportLinks", -0.9627346992492676],
+        ["numberOfPromoLinkOccurrences", 0.892467200756073],
+        ["numberOfPercentOff", 0.6170496940612793],
+        ["isAHelpOrSupportURL", -0.8478246927261353],
+        ["isAJobsURL", -0.6292590498924255],
+        ["isAShopishURL", 0.6362354755401611],
+        ["isAShoppingActionURL", 0.8201884031295776],
+        ["isArticleishURL", -0.3249336779117584],
+        ["numberOfArticleishLinks", -0.5694810152053833],
+        ["hasLinkToStoreFinder", 0.5195519328117371],
+        ["numberOfPrices", 0.5592770576477051],
+        ["numberOfElementsWithCheckoutClass", 0.10612574964761734],
+        ["numberOfElementsWithCheckoutId", 0.2279045581817627],
+        ["numberOfElementsWithCartClass", 0.21071551740169525],
+        ["numberOfElementsWithCartId", 0.3967038094997406],
+        ["numberOfElementsWithShippingClass", 0.6411164402961731],
+        ["numberOfElementsWithShippingId", -0.3398124575614929],
+        ["numberOfElementsWithPaymentClass", 0.4274355173110962],
+        ["numberOfElementsWithPaymentId", 0.7997353672981262]
+      ],
+      [
+        ["shopping", -0.7523059248924255]
+      ]
+    );
+    console.log(shoppingRules.against(this.document).get("shopping")[0].scoreFor("shopping"));
   }
 
   addCSSBorderAndLabel(type) {

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -69,6 +69,7 @@ class FathomChild extends JSWindowActorChild {
   }
 }
 
+// Adapted from mozilla-services/fathom-smoot commit 9612fcddc64096418e95b347f3bf26ca02a600f4
 function makeShoppingRuleset() {
   const {dom, rule, ruleset, score, type} = fathom;
 
@@ -629,6 +630,7 @@ function makeShoppingRuleset() {
   );
 }
 
+// Adapted from mozilla-services/fathom-smoot commit d1f0ca55cf472754fef611656d97681fa6cd049f
 function makeArticleRuleset() {
   const {dom, rule, ruleset, score, type, utils: {linearScale}} = fathom;
 

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -33,11 +33,19 @@ class FathomChild extends JSWindowActorChild {
   executeFathom() {
     const shoppingRules = (new ShoppingRuleset()).makeRuleset();
     const articleRules = (new ArticleRuleset()).makeRuleset();
-    console.log(shoppingRules.against(this.document).get("shopping")[0].scoreFor("shopping"));
-    console.log(articleRules.against(this.document).get("article")[0].scoreFor("article"));
+    const scores = {
+      "shopping": shoppingRules.against(this.document).get("shopping")[0].scoreFor("shopping"),
+      "article": articleRules.against(this.document).get("article")[0].scoreFor("article")
+    };
+    console.log(scores["shopping"]);
+    console.log(scores["article"]);
+    const predictedCategory = Object.keys(scores).reduce((a, b) => scores[a] > scores[b] ? a : b);
+    if (scores[predictedCategory] >= 0.5) {
+      this.addCSSBorderAndLabel(predictedCategory, scores[predictedCategory])
+    }
   }
 
-  addCSSBorderAndLabel(type) {
+  addCSSBorderAndLabel(type, score) {
     const color = COLORS[type];
     if (!color) {
       console.error(
@@ -47,7 +55,8 @@ class FathomChild extends JSWindowActorChild {
     }
     this.document.body.style.border = `5px solid ${color}`;
     const labelElement = this.document.createElement("SPAN");
-    labelElement.style.position = "absolute";
+    labelElement.style.position = "fixed";
+    labelElement.style.zIndex = "1000";
     labelElement.style.padding = "10px";
     labelElement.style.top = "0";
     labelElement.style.left = "50%";
@@ -55,7 +64,7 @@ class FathomChild extends JSWindowActorChild {
     labelElement.style.backgroundColor = color;
     labelElement.style.color = "white";
     labelElement.style.fontSize = "32px";
-    labelElement.innerText = type;
+    labelElement.innerText = `${type}: ${(score * 100).toFixed(2)}% confidence`;
     this.document.body.append(labelElement);
   }
 }

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -31,8 +31,8 @@ class FathomChild extends JSWindowActorChild {
   }
 
   executeFathom() {
-    const shoppingRules = (new ShoppingRuleset()).makeRuleset();
-    const articleRules = (new ArticleRuleset()).makeRuleset();
+    const shoppingRules = makeShoppingRuleset();
+    const articleRules = makeArticleRuleset();
     const scores = {
       "shopping": shoppingRules.against(this.document).get("shopping")[0].scoreFor("shopping"),
       "article": articleRules.against(this.document).get("article")[0].scoreFor("article")
@@ -69,119 +69,121 @@ class FathomChild extends JSWindowActorChild {
   }
 }
 
-class ShoppingRuleset {
-  caselessIncludes(haystack, needle) {
+function makeShoppingRuleset() {
+  const {dom, rule, ruleset, score, type} = fathom;
+
+  function caselessIncludes(haystack, needle) {
     return haystack.toLowerCase().includes(needle.toLowerCase());
   }
 
-  numberOfOccurrencesOf(fnode, text) {
+  function numberOfOccurrencesOf(fnode, text) {
     const regex = new RegExp(text, "gi");
     return (fnode.element.innerText.match(regex) || []).length;
   }
 
-  numberOfCartOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "cart") > 1;
+  function numberOfCartOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "cart") > 1;
   }
 
-  numberOfBuyOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "buy") > 1;
+  function numberOfBuyOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "buy") > 1;
   }
 
-  numberOfCheckoutOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "checkout") > 1;
+  function numberOfCheckoutOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "checkout") > 1;
   }
 
-  numberOfBuyButtons(fnode) {
+  function numberOfBuyButtons(fnode) {
     const buttons = Array.from(fnode.element.querySelectorAll('button,input,a'));
-    return buttons.filter(button => this.caselessIncludes(button.innerText, 'buy')).length > 2;
+    return buttons.filter(button => caselessIncludes(button.innerText, 'buy')).length > 2;
   }
 
-  numberOfShopButtons(fnode) {
+  function numberOfShopButtons(fnode) {
     const buttons = Array.from(fnode.element.querySelectorAll('button,input,a'));
-    return buttons.filter(button => this.caselessIncludes(button.innerText, 'shop')).length > 2;
+    return buttons.filter(button => caselessIncludes(button.innerText, 'shop')).length > 2;
   }
 
-  hasAddToCartButton(fnode) {
+  function hasAddToCartButton(fnode) {
     const buttons = Array.from(fnode.element.querySelectorAll('button, a[class*="btn"]'));
     if (buttons.some(button => {
-      return this.caselessIncludes(button.innerText, 'add to cart') ||
-        this.caselessIncludes(button.innerText, 'add to bag') ||
-        this.caselessIncludes(button.innerText, 'add to basket') ||
-        this.caselessIncludes(button.innerText, 'add to trolley') ||
-        this.caselessIncludes(button.className, 'add-to-cart') ||
-        this.caselessIncludes(button.title, 'add to cart');
+      return caselessIncludes(button.innerText, 'add to cart') ||
+        caselessIncludes(button.innerText, 'add to bag') ||
+        caselessIncludes(button.innerText, 'add to basket') ||
+        caselessIncludes(button.innerText, 'add to trolley') ||
+        caselessIncludes(button.className, 'add-to-cart') ||
+        caselessIncludes(button.title, 'add to cart');
     })) {
       return true;
     }
     const images = Array.from(fnode.element.querySelectorAll('img'));
-    if (images.some(image => this.caselessIncludes(image.title, 'add to cart'))) {
+    if (images.some(image => caselessIncludes(image.title, 'add to cart'))) {
       return true;
     }
     const inputs = Array.from(fnode.element.querySelectorAll('input'));
-    if (inputs.some(input => this.caselessIncludes(input.className, 'add-to-cart'))) {
+    if (inputs.some(input => caselessIncludes(input.className, 'add-to-cart'))) {
       return true;
     }
     const spans = Array.from(fnode.element.querySelectorAll('span'));
     if (spans.some(span => {
-      return this.caselessIncludes(span.className, 'addtocart') ||
-        this.caselessIncludes(span.innerText, 'add to bag') ||
-        this.caselessIncludes(span.innerText, 'add to cart');
+      return caselessIncludes(span.className, 'addtocart') ||
+        caselessIncludes(span.innerText, 'add to bag') ||
+        caselessIncludes(span.innerText, 'add to cart');
     })) {
       return true;
     }
     const links = Array.from(fnode.element.querySelectorAll('a'));
-    return links.some(link => this.caselessIncludes(link.innerText, '加入购物车'));
+    return links.some(link => caselessIncludes(link.innerText, '加入购物车'));
   }
 
-  hasCheckoutButton(fnode) {
+  function hasCheckoutButton(fnode) {
     const divs = Array.from(fnode.element.querySelectorAll('div'));
-    if (divs.some(div => this.caselessIncludes(div.className, 'checkout'))) {
+    if (divs.some(div => caselessIncludes(div.className, 'checkout'))) {
       return true;
     }
     const buttons = Array.from(fnode.element.querySelectorAll('button'));
     if (buttons.some(button => {
-      return this.caselessIncludes(button.innerText, 'checkout') ||
-        this.caselessIncludes(button.innerText, 'check out') ||
-        this.caselessIncludes(button.className, 'checkout');
+      return caselessIncludes(button.innerText, 'checkout') ||
+        caselessIncludes(button.innerText, 'check out') ||
+        caselessIncludes(button.className, 'checkout');
     })) {
       return true;
     }
     const spans = Array.from(fnode.element.querySelectorAll('span'));
-    if (spans.some(span => this.caselessIncludes(span.className, 'checkout'))) {
+    if (spans.some(span => caselessIncludes(span.className, 'checkout'))) {
       return true;
     }
     const links = Array.from(fnode.element.querySelectorAll('a'));
     if (links.some(link => {
-      return this.caselessIncludes(link.innerText, 'checkout') ||
-        this.caselessIncludes(link.href, 'checkout');
+      return caselessIncludes(link.innerText, 'checkout') ||
+        caselessIncludes(link.href, 'checkout');
     })) {
       return true;
     }
     const inputs = Array.from(fnode.element.querySelectorAll('input'));
-    return inputs.some(input => this.caselessIncludes(input.value, 'checkout'));
+    return inputs.some(input => caselessIncludes(input.value, 'checkout'));
   }
 
-  hasLinkToCart(fnode) {
+  function hasLinkToCart(fnode) {
     const links = Array.from(fnode.element.getElementsByTagName('a'));
     if (links.some(link => {
-      return this.caselessIncludes(link.className, 'cart') ||
+      return caselessIncludes(link.className, 'cart') ||
         link.href.endsWith('/cart/') ||
         link.href.endsWith('/cart') ||
-        this.caselessIncludes(this.getAriaLabel(link), 'cart') ||
+        caselessIncludes(getAriaLabel(link), 'cart') ||
         link.href.endsWith('/main_view_cart.php') ||
-        this.caselessIncludes(link.className, '/cart/') ||
+        caselessIncludes(link.className, '/cart/') ||
         link.href.endsWith('/cart.php') ||
         link.href.endsWith('/shoppingCart') ||
         link.href.endsWith('/ShoppingCart') ||
         link.href.endsWith('/shopping_cart.php') ||
-        this.caselessIncludes(link.id, 'cart') ||
-        this.caselessIncludes(link.id, 'basket') ||
-        this.caselessIncludes(link.id, 'bag') ||
-        this.caselessIncludes(link.id, 'trolley') ||
-        this.caselessIncludes(link.className, 'basket') ||
-        this.caselessIncludes(link.className, 'trolley') ||
-        this.caselessIncludes(link.className, 'shoppingbag') ||
-        this.caselessIncludes(link.title, 'cart') ||
+        caselessIncludes(link.id, 'cart') ||
+        caselessIncludes(link.id, 'basket') ||
+        caselessIncludes(link.id, 'bag') ||
+        caselessIncludes(link.id, 'trolley') ||
+        caselessIncludes(link.className, 'basket') ||
+        caselessIncludes(link.className, 'trolley') ||
+        caselessIncludes(link.className, 'shoppingbag') ||
+        caselessIncludes(link.title, 'cart') ||
         link.href.endsWith('/trolley') ||
         link.href.endsWith('/basket') ||
         link.href.endsWith('/bag') ||
@@ -194,25 +196,25 @@ class ShoppingRuleset {
     }
     const buttons = Array.from(fnode.element.querySelectorAll('button'));
     if (buttons.some(button => {
-      return this.caselessIncludes(button.className, 'cart') ||
-        this.caselessIncludes(this.getAriaLabel(button), 'cart');
+      return caselessIncludes(button.className, 'cart') ||
+        caselessIncludes(getAriaLabel(button), 'cart');
     })) {
       return true;
     }
     const spans = Array.from(fnode.element.getElementsByTagName('span'));
     return spans.some(span => {
-      return this.caselessIncludes(span.className, 'cart');
+      return caselessIncludes(span.className, 'cart');
     });
   }
 
-  getAriaLabel(element) {
+  function getAriaLabel(element) {
     if (element.hasAttribute('aria-label')) {
       return element.getAttribute('aria-label');
     }
     return '';
   }
 
-  numberOfLinksToStore(fnode) {
+  function numberOfLinksToStore(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
     return links.filter(link => {
       return link.href.startsWith('https://shop.') ||
@@ -220,35 +222,35 @@ class ShoppingRuleset {
         link.href.startsWith('https://products.') ||
         link.href.endsWith('/shop/') ||
         link.href.endsWith('/products') ||
-        this.caselessIncludes(link.href, '/marketplace/') ||
-        this.caselessIncludes(link.href, '/store/') ||
-        this.caselessIncludes(link.href, '/shop/') ||
+        caselessIncludes(link.href, '/marketplace/') ||
+        caselessIncludes(link.href, '/store/') ||
+        caselessIncludes(link.href, '/shop/') ||
         link.href.endsWith('/store');
     }).length > 2;
   }
 
-  numberOfLinksToCatalog(fnode) {
+  function numberOfLinksToCatalog(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
-    return links.filter(link => this.caselessIncludes(link.href, 'catalog')).length > 1;
+    return links.filter(link => caselessIncludes(link.href, 'catalog')).length > 1;
   }
 
-  hasShoppingCartIcon(fnode) {
+  function hasShoppingCartIcon(fnode) {
     const icons = Array.from(fnode.element.getElementsByTagName('i'));
-    if (icons.some(icon => this.caselessIncludes(icon.className, 'cart'))) {
+    if (icons.some(icon => caselessIncludes(icon.className, 'cart'))) {
       return true
     }
     const imgs = Array.from(fnode.element.getElementsByTagName('img'));
-    if (imgs.some(img => this.caselessIncludes(img.src, 'cart'))) {
+    if (imgs.some(img => caselessIncludes(img.src, 'cart'))) {
       return true
     }
     const spans = Array.from(fnode.element.getElementsByTagName('span'));
     return spans.some(span => {
-      return this.caselessIncludes(span.className, 'cart') ||
-        this.caselessIncludes(span.className, 'trolley');
+      return caselessIncludes(span.className, 'cart') ||
+        caselessIncludes(span.className, 'trolley');
     })
   }
 
-  hasStarRatings(fnode) {
+  function hasStarRatings(fnode) {
     const divs = Array.from(fnode.element.querySelectorAll('div[class*="rating" i], div[class*="review" i]'));
     return divs.some(div => {
       const stars = div.querySelectorAll('span[class*="star" i], i[class*="star" i], div[type*="star" i], div[class*="star" i], svg[class*="star" i]');
@@ -256,91 +258,91 @@ class ShoppingRuleset {
     });
   }
 
-  numberOfCurrencySymbols(fnode) {
+  function numberOfCurrencySymbols(fnode) {
     const currencies = /[$£€¥]/g;
     return (fnode.element.innerText.match(currencies) || []).length >= 4;
   }
 
-  numberOfShippingAddressOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "shipping address") >= 1;
+  function numberOfShippingAddressOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "shipping address") >= 1;
   }
 
-  numberOfBillingAddressOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "billing address") >= 2;
+  function numberOfBillingAddressOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "billing address") >= 2;
   }
 
-  numberOfPaymentMethodOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "payment method") >= 1;
+  function numberOfPaymentMethodOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "payment method") >= 1;
   }
 
-  numberOfShippingMethodOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "shipping method") >= 1;
+  function numberOfShippingMethodOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "shipping method") >= 1;
   }
 
-  numberOfStockPhraseOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "in stock") + this.numberOfOccurrencesOf(fnode, "out of stock") >= 1;
+  function numberOfStockPhraseOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "in stock") + numberOfOccurrencesOf(fnode, "out of stock") >= 1;
   }
 
-  numberOfContinueShoppingOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "continue shopping") >= 1;
+  function numberOfContinueShoppingOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "continue shopping") >= 1;
   }
 
-  numberOfPolicyOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "policy") >= 1;
+  function numberOfPolicyOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "policy") >= 1;
   }
 
-  numberOfTermsOccurrences(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "terms") >= 1;
+  function numberOfTermsOccurrences(fnode) {
+    return numberOfOccurrencesOf(fnode, "terms") >= 1;
   }
 
-  numberOfLinksToSale(fnode) {
+  function numberOfLinksToSale(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
     return links.filter(link => {
-      return this.caselessIncludes(link.href, 'sale') ||
-        this.caselessIncludes(link.href, 'deals') ||
-        this.caselessIncludes(link.href, 'clearance');
+      return caselessIncludes(link.href, 'sale') ||
+        caselessIncludes(link.href, 'deals') ||
+        caselessIncludes(link.href, 'clearance');
     }).length >= 1;
   }
 
-  numberOfProductLinks(fnode) {
+  function numberOfProductLinks(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
-    return links.filter(link => this.caselessIncludes(link.href, 'product')).length >= 5;
+    return links.filter(link => caselessIncludes(link.href, 'product')).length >= 5;
   }
 
-  numberOfElementsWithProductClass(fnode) {
+  function numberOfElementsWithProductClass(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[class*="product" i]')).length >= 4;
   }
 
-  numberOfElementsWithProductId(fnode) {
+  function numberOfElementsWithProductId(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[id*="product" i]')).length >= 1;
   }
 
-  hasOrderForm(fnode) {
+  function hasOrderForm(fnode) {
     const forms = Array.from(fnode.element.getElementsByTagName('form'));
     return forms.some(form => {
-      return this.caselessIncludes(form.name, 'order') ||
-        this.caselessIncludes(form.name, 'shipping') ||
-        this.caselessIncludes(form.name, 'payment') ||
-        this.caselessIncludes(form.name, 'checkout') ||
-        this.caselessIncludes(form.name, 'address') ||
-        this.caselessIncludes(form.name, 'product');
+      return caselessIncludes(form.name, 'order') ||
+        caselessIncludes(form.name, 'shipping') ||
+        caselessIncludes(form.name, 'payment') ||
+        caselessIncludes(form.name, 'checkout') ||
+        caselessIncludes(form.name, 'address') ||
+        caselessIncludes(form.name, 'product');
     })
   }
 
-  hasContactForm(fnode) {
+  function hasContactForm(fnode) {
     const forms = Array.from(fnode.element.getElementsByTagName('form'));
     return forms.some(form => {
-      return this.caselessIncludes(form.name, 'contact') ||
-        this.caselessIncludes(form.name, 'question');
+      return caselessIncludes(form.name, 'contact') ||
+        caselessIncludes(form.name, 'question');
     })
   }
 
-  numberOfHelpOrSupportLinks(fnode) {
+  function numberOfHelpOrSupportLinks(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
     return links.filter(link => {
       try {
         const url = new URL(link.href);
-        return this.urlIsHelpOrSupport(url)
+        return urlIsHelpOrSupport(url)
       } catch (e) {
         // None empty strings that are not valid URLs
         return false
@@ -348,124 +350,124 @@ class ShoppingRuleset {
     }).length >= 1;
   }
 
-  numberOfPromoLinkOccurrences(fnode) {
+  function numberOfPromoLinkOccurrences(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
-    return links.filter(link => this.caselessIncludes(link.href, 'promo')).length >= 2;
+    return links.filter(link => caselessIncludes(link.href, 'promo')).length >= 2;
   }
 
-  numberOfPercentOff(fnode) {
-    return this.numberOfOccurrencesOf(fnode, "% off") >= 1;
+  function numberOfPercentOff(fnode) {
+    return numberOfOccurrencesOf(fnode, "% off") >= 1;
   }
 
-  isAHelpOrSupportURL(fnode) {
+  function isAHelpOrSupportURL(fnode) {
     const pageURL = new URL(fnode.element.ownerDocument.URL);
-    return this.urlIsHelpOrSupport(pageURL);
+    return urlIsHelpOrSupport(pageURL);
   }
 
-  urlIsHelpOrSupport(url) {
+  function urlIsHelpOrSupport(url) {
     const domainPieces = url.hostname.split(".");
     const subdomain = domainPieces[0];
-    if (this.caselessIncludes(subdomain, 'help') || this.caselessIncludes(subdomain, 'support')) {
+    if (caselessIncludes(subdomain, 'help') || caselessIncludes(subdomain, 'support')) {
       return true;
     }
     const topLevelDomain = domainPieces[domainPieces.length - 1];
-    if (this.caselessIncludes(topLevelDomain, 'help') || this.caselessIncludes(topLevelDomain, 'support')) {
+    if (caselessIncludes(topLevelDomain, 'help') || caselessIncludes(topLevelDomain, 'support')) {
       return true;
     }
     const pathname = url.pathname;
     return (
-      this.caselessIncludes(pathname, 'help') ||
-      this.caselessIncludes(pathname, 'support') ||
-      this.caselessIncludes(pathname, 'contact') ||
-      this.caselessIncludes(pathname, 'policy') ||
-      this.caselessIncludes(pathname, 'terms') ||
-      this.caselessIncludes(pathname, 'troubleshooting')
+      caselessIncludes(pathname, 'help') ||
+      caselessIncludes(pathname, 'support') ||
+      caselessIncludes(pathname, 'contact') ||
+      caselessIncludes(pathname, 'policy') ||
+      caselessIncludes(pathname, 'terms') ||
+      caselessIncludes(pathname, 'troubleshooting')
     );
   }
 
-  isAJobsURL(fnode) {
+  function isAJobsURL(fnode) {
     const pageURL = new URL(fnode.element.ownerDocument.URL);
     const domainPieces = pageURL.hostname.split(".");
     const subdomain = domainPieces[0];
-    if (this.caselessIncludes(subdomain, 'jobs') || this.caselessIncludes(subdomain, 'careers')) {
+    if (caselessIncludes(subdomain, 'jobs') || caselessIncludes(subdomain, 'careers')) {
       return true;
     }
     const topLevelDomain = domainPieces[domainPieces.length - 1];
-    if (this.caselessIncludes(topLevelDomain, 'jobs') || this.caselessIncludes(topLevelDomain, 'careers')) {
+    if (caselessIncludes(topLevelDomain, 'jobs') || caselessIncludes(topLevelDomain, 'careers')) {
       return true;
     }
     const pathname = pageURL.pathname;
     return (
-      this.caselessIncludes(pathname, 'jobs') ||
-      this.caselessIncludes(pathname, 'careers')
+      caselessIncludes(pathname, 'jobs') ||
+      caselessIncludes(pathname, 'careers')
     );
   }
 
-  isAShopishURL(fnode) {
+  function isAShopishURL(fnode) {
     const pageURL = new URL(fnode.element.ownerDocument.URL);
     const domainPieces = pageURL.hostname.split(".");
     const subdomain = domainPieces[0];
-    if (this.caselessIncludes(subdomain, 'shop') || this.caselessIncludes(subdomain, 'store')) {
+    if (caselessIncludes(subdomain, 'shop') || caselessIncludes(subdomain, 'store')) {
       return true;
     }
     const topLevelDomain = domainPieces[domainPieces.length - 1];
-    if (this.caselessIncludes(topLevelDomain, 'shop') || this.caselessIncludes(topLevelDomain, 'store')) {
+    if (caselessIncludes(topLevelDomain, 'shop') || caselessIncludes(topLevelDomain, 'store')) {
       return true;
     }
     const pathname = pageURL.pathname;
     return (
-      this.caselessIncludes(pathname, 'product') ||
-      this.caselessIncludes(pathname, 'store') ||
-      this.caselessIncludes(pathname, 'marketplace') ||
-      this.caselessIncludes(pathname, 'catalog') ||
-      this.caselessIncludes(pathname, 'shop')
+      caselessIncludes(pathname, 'product') ||
+      caselessIncludes(pathname, 'store') ||
+      caselessIncludes(pathname, 'marketplace') ||
+      caselessIncludes(pathname, 'catalog') ||
+      caselessIncludes(pathname, 'shop')
     );
   }
 
   // TODO: Should this just be part of `isAShopishURL`?
-  isAShoppingActionURL(fnode) {
+  function isAShoppingActionURL(fnode) {
     const pageURL = new URL(fnode.element.ownerDocument.URL);
     const pathname = pageURL.pathname;
     return (
-      this.caselessIncludes(pathname, 'cart') ||
-      this.caselessIncludes(pathname, 'checkout') ||
-      this.caselessIncludes(pathname, 'wishlist') ||
-      this.caselessIncludes(pathname, 'deals') ||
-      this.caselessIncludes(pathname, 'sales') ||
-      this.caselessIncludes(pathname, 'pricing') ||
-      this.caselessIncludes(pathname, 'basket') ||
-      this.caselessIncludes(pathname, 'wish-list')
+      caselessIncludes(pathname, 'cart') ||
+      caselessIncludes(pathname, 'checkout') ||
+      caselessIncludes(pathname, 'wishlist') ||
+      caselessIncludes(pathname, 'deals') ||
+      caselessIncludes(pathname, 'sales') ||
+      caselessIncludes(pathname, 'pricing') ||
+      caselessIncludes(pathname, 'basket') ||
+      caselessIncludes(pathname, 'wish-list')
     );
   }
 
-  isArticleishURL(fnode) {
+  function isArticleishURL(fnode) {
     const pageURL = new URL(fnode.element.ownerDocument.URL);
-    return this.isArticleish(pageURL)
+    return isArticleish(pageURL)
   }
 
-  isArticleish(url) {
+  function isArticleish(url) {
     const domainPieces = url.hostname.split(".");
     const subdomain = domainPieces[0];
-    if (this.caselessIncludes(subdomain, 'blog') || this.caselessIncludes(subdomain, 'news')) {
+    if (caselessIncludes(subdomain, 'blog') || caselessIncludes(subdomain, 'news')) {
       return true;
     }
     const topLevelDomain = domainPieces[domainPieces.length - 1];
-    if (this.caselessIncludes(topLevelDomain, 'blog') || this.caselessIncludes(topLevelDomain, 'news')) {
+    if (caselessIncludes(topLevelDomain, 'blog') || caselessIncludes(topLevelDomain, 'news')) {
       return true;
     }
     const pathname = url.pathname;
     return (
-      this.caselessIncludes(pathname, 'blog') ||
-      this.caselessIncludes(pathname, 'news')
+      caselessIncludes(pathname, 'blog') ||
+      caselessIncludes(pathname, 'news')
     );
   }
 
-  numberOfArticleishLinks(fnode) {
+  function numberOfArticleishLinks(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
     return links.filter(link => {
       try {
         const pageURL = new URL(link.href);
-        return this.isArticleish(pageURL)
+        return isArticleish(pageURL)
       } catch (e) {
         // None empty strings that are not valid URLs
         return false
@@ -473,174 +475,171 @@ class ShoppingRuleset {
     }).length >= 1;
   }
 
-  hasLinkToStoreFinder(fnode) {
+  function hasLinkToStoreFinder(fnode) {
     const links = Array.from(fnode.element.querySelectorAll('a[href]:not([href=""])'));
     return links.some(link => {
-      return this.caselessIncludes(link.href, 'storelocator') ||
-        this.caselessIncludes(link.href, 'storefinder') ||
-        this.caselessIncludes(link.innerText, 'store locator') ||
-        this.caselessIncludes(link.innerText, 'store finder') ||
-        this.caselessIncludes(link.innerText, 'locate a store') ||
-        this.caselessIncludes(link.innerText, 'find a store');
+      return caselessIncludes(link.href, 'storelocator') ||
+        caselessIncludes(link.href, 'storefinder') ||
+        caselessIncludes(link.innerText, 'store locator') ||
+        caselessIncludes(link.innerText, 'store finder') ||
+        caselessIncludes(link.innerText, 'locate a store') ||
+        caselessIncludes(link.innerText, 'find a store');
     })
   }
 
-  numberOfPrices(fnode) {
+  function numberOfPrices(fnode) {
     const price = /\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2})/g;
     return (fnode.element.innerText.match(price) || []).length >= 5;
   }
 
-  numberOfElementsWithCheckoutClass(fnode) {
+  function numberOfElementsWithCheckoutClass(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[class*="checkout" i]')).length >= 1;
   }
 
-  numberOfElementsWithCheckoutId(fnode) {
+  function numberOfElementsWithCheckoutId(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[id*="checkout" i]')).length >= 1;
   }
 
-  numberOfElementsWithCartClass(fnode) {
+  function numberOfElementsWithCartClass(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[class*="cart" i]')).length >= 1;
   }
 
-  numberOfElementsWithCartId(fnode) {
+  function numberOfElementsWithCartId(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[id*="cart" i]')).length >= 1;
   }
 
-  numberOfElementsWithShippingClass(fnode) {
+  function numberOfElementsWithShippingClass(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[class*="shipping" i]')).length >= 1;
   }
 
-  numberOfElementsWithShippingId(fnode) {
+  function numberOfElementsWithShippingId(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[id*="shipping" i]')).length >= 1;
   }
 
-  numberOfElementsWithPaymentClass(fnode) {
+  function numberOfElementsWithPaymentClass(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[class*="payment" i]')).length >= 1;
   }
 
-  numberOfElementsWithPaymentId(fnode) {
+  function numberOfElementsWithPaymentId(fnode) {
     return Array.from(fnode.element.querySelectorAll('*[id*="payment" i]')).length >= 1;
   }
 
-  makeRuleset() {
-    const {dom, rule, ruleset, score, type} = fathom;
-    return ruleset(
-      [
-        rule(dom('html'), type('shopping')),
-        rule(type('shopping'), score(this.numberOfCartOccurrences.bind(this)), {name: 'numberOfCartOccurrences'}),
-        rule(type('shopping'), score(this.numberOfBuyOccurrences.bind(this)), {name: 'numberOfBuyOccurrences'}),
-        rule(type('shopping'), score(this.numberOfCheckoutOccurrences.bind(this)), {name: 'numberOfCheckoutOccurrences'}),
-        rule(type('shopping'), score(this.numberOfBuyButtons.bind(this)), {name: 'numberOfBuyButtons'}),
-        rule(type('shopping'), score(this.numberOfShopButtons.bind(this)), {name: 'numberOfShopButtons'}),
-        rule(type('shopping'), score(this.hasAddToCartButton.bind(this)), {name: 'hasAddToCartButton'}),
-        rule(type('shopping'), score(this.hasCheckoutButton.bind(this)), {name: 'hasCheckoutButton'}),
-        rule(type('shopping'), score(this.hasLinkToCart.bind(this)), {name: 'hasLinkToCart'}),
-        rule(type('shopping'), score(this.numberOfLinksToStore.bind(this)), {name: 'numberOfLinksToStore'}),
-        rule(type('shopping'), score(this.numberOfLinksToCatalog.bind(this)), {name: 'numberOfLinksToCatalog'}),
-        rule(type('shopping'), score(this.hasShoppingCartIcon.bind(this)), {name: 'hasShoppingCartIcon'}),
-        rule(type('shopping'), score(this.hasStarRatings.bind(this)), {name: 'hasStarRatings'}),
-        rule(type('shopping'), score(this.numberOfCurrencySymbols.bind(this)), {name: 'numberOfCurrencySymbols'}),
-        rule(type('shopping'), score(this.numberOfShippingAddressOccurrences.bind(this)), {name: 'numberOfShippingAddressOccurrences'}),
-        rule(type('shopping'), score(this.numberOfBillingAddressOccurrences.bind(this)), {name: 'numberOfBillingAddressOccurrences'}),
-        rule(type('shopping'), score(this.numberOfPaymentMethodOccurrences.bind(this)), {name: 'numberOfPaymentMethodOccurrences'}),
-        rule(type('shopping'), score(this.numberOfShippingMethodOccurrences.bind(this)), {name: 'numberOfShippingMethodOccurrences'}),
-        rule(type('shopping'), score(this.numberOfStockPhraseOccurrences.bind(this)), {name: 'numberOfStockPhraseOccurrences'}),
-        rule(type('shopping'), score(this.numberOfContinueShoppingOccurrences.bind(this)), {name: 'numberOfContinueShoppingOccurrences'}),
-        rule(type('shopping'), score(this.numberOfPolicyOccurrences.bind(this)), {name: 'numberOfPolicyOccurrences'}),
-        rule(type('shopping'), score(this.numberOfTermsOccurrences.bind(this)), {name: 'numberOfTermsOccurrences'}),
-        rule(type('shopping'), score(this.numberOfLinksToSale.bind(this)), {name: 'numberOfLinksToSale'}),
-        rule(type('shopping'), score(this.numberOfProductLinks.bind(this)), {name: 'numberOfProductLinks'}),
-        rule(type('shopping'), score(this.numberOfElementsWithProductClass.bind(this)), {name: 'numberOfElementsWithProductClass'}),
-        rule(type('shopping'), score(this.numberOfElementsWithProductId.bind(this)), {name: 'numberOfElementsWithProductId'}),
-        rule(type('shopping'), score(this.hasOrderForm.bind(this)), {name: 'hasOrderForm'}),
-        rule(type('shopping'), score(this.hasContactForm.bind(this)), {name: 'hasContactForm'}),
-        rule(type('shopping'), score(this.numberOfHelpOrSupportLinks.bind(this)), {name: 'numberOfHelpOrSupportLinks'}),
-        rule(type('shopping'), score(this.numberOfPromoLinkOccurrences.bind(this)), {name: 'numberOfPromoLinkOccurrences'}),
-        rule(type('shopping'), score(this.numberOfPercentOff.bind(this)), {name: 'numberOfPercentOff'}),
-        rule(type('shopping'), score(this.isAHelpOrSupportURL.bind(this)), {name: 'isAHelpOrSupportURL'}),
-        rule(type('shopping'), score(this.isAJobsURL.bind(this)), {name: 'isAJobsURL'}),
-        rule(type('shopping'), score(this.isAShopishURL.bind(this)), {name: 'isAShopishURL'}),
-        rule(type('shopping'), score(this.isAShoppingActionURL.bind(this)), {name: 'isAShoppingActionURL'}),
-        rule(type('shopping'), score(this.isArticleishURL.bind(this)), {name: 'isArticleishURL'}),
-        rule(type('shopping'), score(this.numberOfArticleishLinks.bind(this)), {name: 'numberOfArticleishLinks'}),
-        rule(type('shopping'), score(this.hasLinkToStoreFinder.bind(this)), {name: 'hasLinkToStoreFinder'}),
-        rule(type('shopping'), score(this.numberOfPrices.bind(this)), {name: 'numberOfPrices'}),
-        rule(type('shopping'), score(this.numberOfElementsWithCheckoutClass.bind(this)), {name: 'numberOfElementsWithCheckoutClass'}),
-        rule(type('shopping'), score(this.numberOfElementsWithCheckoutId.bind(this)), {name: 'numberOfElementsWithCheckoutId'}),
-        rule(type('shopping'), score(this.numberOfElementsWithCartClass.bind(this)), {name: 'numberOfElementsWithCartClass'}),
-        rule(type('shopping'), score(this.numberOfElementsWithCartId.bind(this)), {name: 'numberOfElementsWithCartId'}),
-        rule(type('shopping'), score(this.numberOfElementsWithShippingClass.bind(this)), {name: 'numberOfElementsWithShippingClass'}),
-        rule(type('shopping'), score(this.numberOfElementsWithShippingId.bind(this)), {name: 'numberOfElementsWithShippingId'}),
-        rule(type('shopping'), score(this.numberOfElementsWithPaymentClass.bind(this)), {name: 'numberOfElementsWithPaymentClass'}),
-        rule(type('shopping'), score(this.numberOfElementsWithPaymentId.bind(this)), {name: 'numberOfElementsWithPaymentId'}),
-        rule(type('shopping'), 'shopping')
-      ],
-      [
-        ["numberOfCartOccurrences", 0.004431677050888538],
-        ["numberOfBuyOccurrences", 0.37095534801483154],
-        ["numberOfCheckoutOccurrences", 0.003904791548848152],
-        ["numberOfBuyButtons", 0.5181145071983337],
-        ["numberOfShopButtons", 0.09862659871578217],
-        ["hasAddToCartButton", 0.5496213436126709],
-        ["hasCheckoutButton", 0.41033145785331726],
-        ["hasLinkToCart", 0.37247663736343384],
-        ["numberOfLinksToStore", 0.6745859980583191],
-        ["numberOfLinksToCatalog", 0.39251187443733215],
-        ["hasShoppingCartIcon", 0.34280550479888916],
-        ["hasStarRatings", 0.5168086886405945],
-        ["numberOfCurrencySymbols", 0.7948866486549377],
-        ["numberOfShippingAddressOccurrences", 0.8619705438613892],
-        ["numberOfBillingAddressOccurrences", 0.3214116096496582],
-        ["numberOfPaymentMethodOccurrences", -0.26714643836021423],
-        ["numberOfShippingMethodOccurrences", 0.3138491213321686],
-        ["numberOfStockPhraseOccurrences", 0.5305109620094299],
-        ["numberOfContinueShoppingOccurrences", 0.8661705255508423],
-        ["numberOfPolicyOccurrences", -0.014949105679988861],
-        ["numberOfTermsOccurrences", -0.5102343559265137],
-        ["numberOfLinksToSale", 0.6466160416603088],
-        ["numberOfProductLinks", 0.5545489192008972],
-        ["numberOfElementsWithProductClass", 0.5344703197479248],
-        ["numberOfElementsWithProductId", 0.3443285822868347],
-        ["hasOrderForm", 0.7178601026535034],
-        ["hasContactForm", -1.2140718698501587],
-        ["numberOfHelpOrSupportLinks", -0.9627346992492676],
-        ["numberOfPromoLinkOccurrences", 0.892467200756073],
-        ["numberOfPercentOff", 0.6170496940612793],
-        ["isAHelpOrSupportURL", -0.8478246927261353],
-        ["isAJobsURL", -0.6292590498924255],
-        ["isAShopishURL", 0.6362354755401611],
-        ["isAShoppingActionURL", 0.8201884031295776],
-        ["isArticleishURL", -0.3249336779117584],
-        ["numberOfArticleishLinks", -0.5694810152053833],
-        ["hasLinkToStoreFinder", 0.5195519328117371],
-        ["numberOfPrices", 0.5592770576477051],
-        ["numberOfElementsWithCheckoutClass", 0.10612574964761734],
-        ["numberOfElementsWithCheckoutId", 0.2279045581817627],
-        ["numberOfElementsWithCartClass", 0.21071551740169525],
-        ["numberOfElementsWithCartId", 0.3967038094997406],
-        ["numberOfElementsWithShippingClass", 0.6411164402961731],
-        ["numberOfElementsWithShippingId", -0.3398124575614929],
-        ["numberOfElementsWithPaymentClass", 0.4274355173110962],
-        ["numberOfElementsWithPaymentId", 0.7997353672981262]
-      ],
-      [
-        ["shopping", -0.7523059248924255]
-      ]
-    );
-  }
+  return ruleset(
+    [
+      rule(dom('html'), type('shopping')),
+      rule(type('shopping'), score(numberOfCartOccurrences), {name: 'numberOfCartOccurrences'}),
+      rule(type('shopping'), score(numberOfBuyOccurrences), {name: 'numberOfBuyOccurrences'}),
+      rule(type('shopping'), score(numberOfCheckoutOccurrences), {name: 'numberOfCheckoutOccurrences'}),
+      rule(type('shopping'), score(numberOfBuyButtons), {name: 'numberOfBuyButtons'}),
+      rule(type('shopping'), score(numberOfShopButtons), {name: 'numberOfShopButtons'}),
+      rule(type('shopping'), score(hasAddToCartButton), {name: 'hasAddToCartButton'}),
+      rule(type('shopping'), score(hasCheckoutButton), {name: 'hasCheckoutButton'}),
+      rule(type('shopping'), score(hasLinkToCart), {name: 'hasLinkToCart'}),
+      rule(type('shopping'), score(numberOfLinksToStore), {name: 'numberOfLinksToStore'}),
+      rule(type('shopping'), score(numberOfLinksToCatalog), {name: 'numberOfLinksToCatalog'}),
+      rule(type('shopping'), score(hasShoppingCartIcon), {name: 'hasShoppingCartIcon'}),
+      rule(type('shopping'), score(hasStarRatings), {name: 'hasStarRatings'}),
+      rule(type('shopping'), score(numberOfCurrencySymbols), {name: 'numberOfCurrencySymbols'}),
+      rule(type('shopping'), score(numberOfShippingAddressOccurrences), {name: 'numberOfShippingAddressOccurrences'}),
+      rule(type('shopping'), score(numberOfBillingAddressOccurrences), {name: 'numberOfBillingAddressOccurrences'}),
+      rule(type('shopping'), score(numberOfPaymentMethodOccurrences), {name: 'numberOfPaymentMethodOccurrences'}),
+      rule(type('shopping'), score(numberOfShippingMethodOccurrences), {name: 'numberOfShippingMethodOccurrences'}),
+      rule(type('shopping'), score(numberOfStockPhraseOccurrences), {name: 'numberOfStockPhraseOccurrences'}),
+      rule(type('shopping'), score(numberOfContinueShoppingOccurrences), {name: 'numberOfContinueShoppingOccurrences'}),
+      rule(type('shopping'), score(numberOfPolicyOccurrences), {name: 'numberOfPolicyOccurrences'}),
+      rule(type('shopping'), score(numberOfTermsOccurrences), {name: 'numberOfTermsOccurrences'}),
+      rule(type('shopping'), score(numberOfLinksToSale), {name: 'numberOfLinksToSale'}),
+      rule(type('shopping'), score(numberOfProductLinks), {name: 'numberOfProductLinks'}),
+      rule(type('shopping'), score(numberOfElementsWithProductClass), {name: 'numberOfElementsWithProductClass'}),
+      rule(type('shopping'), score(numberOfElementsWithProductId), {name: 'numberOfElementsWithProductId'}),
+      rule(type('shopping'), score(hasOrderForm), {name: 'hasOrderForm'}),
+      rule(type('shopping'), score(hasContactForm), {name: 'hasContactForm'}),
+      rule(type('shopping'), score(numberOfHelpOrSupportLinks), {name: 'numberOfHelpOrSupportLinks'}),
+      rule(type('shopping'), score(numberOfPromoLinkOccurrences), {name: 'numberOfPromoLinkOccurrences'}),
+      rule(type('shopping'), score(numberOfPercentOff), {name: 'numberOfPercentOff'}),
+      rule(type('shopping'), score(isAHelpOrSupportURL), {name: 'isAHelpOrSupportURL'}),
+      rule(type('shopping'), score(isAJobsURL), {name: 'isAJobsURL'}),
+      rule(type('shopping'), score(isAShopishURL), {name: 'isAShopishURL'}),
+      rule(type('shopping'), score(isAShoppingActionURL), {name: 'isAShoppingActionURL'}),
+      rule(type('shopping'), score(isArticleishURL), {name: 'isArticleishURL'}),
+      rule(type('shopping'), score(numberOfArticleishLinks), {name: 'numberOfArticleishLinks'}),
+      rule(type('shopping'), score(hasLinkToStoreFinder), {name: 'hasLinkToStoreFinder'}),
+      rule(type('shopping'), score(numberOfPrices), {name: 'numberOfPrices'}),
+      rule(type('shopping'), score(numberOfElementsWithCheckoutClass), {name: 'numberOfElementsWithCheckoutClass'}),
+      rule(type('shopping'), score(numberOfElementsWithCheckoutId), {name: 'numberOfElementsWithCheckoutId'}),
+      rule(type('shopping'), score(numberOfElementsWithCartClass), {name: 'numberOfElementsWithCartClass'}),
+      rule(type('shopping'), score(numberOfElementsWithCartId), {name: 'numberOfElementsWithCartId'}),
+      rule(type('shopping'), score(numberOfElementsWithShippingClass), {name: 'numberOfElementsWithShippingClass'}),
+      rule(type('shopping'), score(numberOfElementsWithShippingId), {name: 'numberOfElementsWithShippingId'}),
+      rule(type('shopping'), score(numberOfElementsWithPaymentClass), {name: 'numberOfElementsWithPaymentClass'}),
+      rule(type('shopping'), score(numberOfElementsWithPaymentId), {name: 'numberOfElementsWithPaymentId'}),
+      rule(type('shopping'), 'shopping')
+    ],
+    [
+      ["numberOfCartOccurrences", 0.004431677050888538],
+      ["numberOfBuyOccurrences", 0.37095534801483154],
+      ["numberOfCheckoutOccurrences", 0.003904791548848152],
+      ["numberOfBuyButtons", 0.5181145071983337],
+      ["numberOfShopButtons", 0.09862659871578217],
+      ["hasAddToCartButton", 0.5496213436126709],
+      ["hasCheckoutButton", 0.41033145785331726],
+      ["hasLinkToCart", 0.37247663736343384],
+      ["numberOfLinksToStore", 0.6745859980583191],
+      ["numberOfLinksToCatalog", 0.39251187443733215],
+      ["hasShoppingCartIcon", 0.34280550479888916],
+      ["hasStarRatings", 0.5168086886405945],
+      ["numberOfCurrencySymbols", 0.7948866486549377],
+      ["numberOfShippingAddressOccurrences", 0.8619705438613892],
+      ["numberOfBillingAddressOccurrences", 0.3214116096496582],
+      ["numberOfPaymentMethodOccurrences", -0.26714643836021423],
+      ["numberOfShippingMethodOccurrences", 0.3138491213321686],
+      ["numberOfStockPhraseOccurrences", 0.5305109620094299],
+      ["numberOfContinueShoppingOccurrences", 0.8661705255508423],
+      ["numberOfPolicyOccurrences", -0.014949105679988861],
+      ["numberOfTermsOccurrences", -0.5102343559265137],
+      ["numberOfLinksToSale", 0.6466160416603088],
+      ["numberOfProductLinks", 0.5545489192008972],
+      ["numberOfElementsWithProductClass", 0.5344703197479248],
+      ["numberOfElementsWithProductId", 0.3443285822868347],
+      ["hasOrderForm", 0.7178601026535034],
+      ["hasContactForm", -1.2140718698501587],
+      ["numberOfHelpOrSupportLinks", -0.9627346992492676],
+      ["numberOfPromoLinkOccurrences", 0.892467200756073],
+      ["numberOfPercentOff", 0.6170496940612793],
+      ["isAHelpOrSupportURL", -0.8478246927261353],
+      ["isAJobsURL", -0.6292590498924255],
+      ["isAShopishURL", 0.6362354755401611],
+      ["isAShoppingActionURL", 0.8201884031295776],
+      ["isArticleishURL", -0.3249336779117584],
+      ["numberOfArticleishLinks", -0.5694810152053833],
+      ["hasLinkToStoreFinder", 0.5195519328117371],
+      ["numberOfPrices", 0.5592770576477051],
+      ["numberOfElementsWithCheckoutClass", 0.10612574964761734],
+      ["numberOfElementsWithCheckoutId", 0.2279045581817627],
+      ["numberOfElementsWithCartClass", 0.21071551740169525],
+      ["numberOfElementsWithCartId", 0.3967038094997406],
+      ["numberOfElementsWithShippingClass", 0.6411164402961731],
+      ["numberOfElementsWithShippingId", -0.3398124575614929],
+      ["numberOfElementsWithPaymentClass", 0.4274355173110962],
+      ["numberOfElementsWithPaymentId", 0.7997353672981262]
+    ],
+    [
+      ["shopping", -0.7523059248924255]
+    ]
+  );
 }
 
-class ArticleRuleset {
-  constructor() {
-    // Memoize expensive results, so they are only computed once.
-    this.highestScoringParagraphs = null;
-    this.numParagraphsInAllDivs = null;
-  }
+function makeArticleRuleset() {
+  const {dom, rule, ruleset, score, type, utils: {linearScale}} = fathom;
+
+  // Memoize expensive results, so they are only computed once.
+  let highestScoringParagraphs;
+  let numParagraphsInAllDivs;
 
   // Text nodes are not targetable via document.querySelectorAll (i.e. Fathom's `dom` method).
   // We instead use a heuristic to estimate the number of paragraph-like text nodes based on the
   // number of descendant <br> elements and list elements in the <div>
-  numParagraphTextNodesInDiv({element}) {
+  function numParagraphTextNodesInDiv({element}) {
     if (element.tagName !== "DIV") {
       return 0;
     }
@@ -650,14 +649,14 @@ class ArticleRuleset {
     return (brDescendants.length - listDescendants.length + 1);
   }
 
-  getNumParagraphsInAllDivs(paragraphFnodes) {
+  function getNumParagraphsInAllDivs(paragraphFnodes) {
     const divWithBrFnodes = paragraphFnodes.filter(({element}) => element.tagName === "DIV");
     return divWithBrFnodes.reduce((accumulator, currentValue) => {
       return accumulator + currentValue.noteFor("paragraph");
     }, 0);
   }
 
-  isElementVisible({element}) {
+  function isElementVisible({element}) {
     // Have to null-check element.style to deal with SVG and MathML nodes.
     return (
       (!element.style || element.style.display != "none")
@@ -665,38 +664,38 @@ class ArticleRuleset {
     );
   }
 
-  divHasBrChildElement({element}) {
+  function divHasBrChildElement({element}) {
     if (element.tagName !== "DIV") {
       return true;
     }
     return Array.from(element.children).some((childEle) => childEle.tagName === "BR");
   }
 
-  pElementHasNoListItemAncestor({element}) {
+  function pElementHasNoListItemAncestor({element}) {
     return !element.matches("li p");
   }
 
-  hasLongTextContent({element}) {
+  function hasLongTextContent({element}) {
     const textContentLength = element.textContent.trim().length;
     return textContentLength >= 234; // Optimized with 10 sample pages; see /vectors/rule_output_analysis.ipynb
   }
 
-  getHighestScoringParagraphs(fnode) {
+  function getHighestScoringParagraphs(fnode) {
     return fnode._ruleset.get("paragraph");
   }
 
-  hasEnoughParagraphs(fnode) {
-    const paragraphFnodes = this.highestScoringParagraphs || this.getHighestScoringParagraphs(fnode);
-    const paragraphsInDivsWithBrs = this.numParagraphsInAllDivs || this.getNumParagraphsInAllDivs(paragraphFnodes);
+  function hasEnoughParagraphs(fnode) {
+    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    const paragraphsInDivsWithBrs = numParagraphsInAllDivs || getNumParagraphsInAllDivs(paragraphFnodes);
     return (paragraphFnodes.length + paragraphsInDivsWithBrs) >= 9; // Optimized with 40 training samples
   }
 
-  hasArticleElement(fnode) {
+  function hasArticleElement(fnode) {
     return !!(fnode.element.ownerDocument.querySelector("article"));
   }
 
-  paragraphElementsHaveSiblingsWithSameTagName(fnode) {
-    const paragraphFnodes = this.highestScoringParagraphs || this.getHighestScoringParagraphs(fnode);
+  function paragraphElementsHaveSiblingsWithSameTagName(fnode) {
+    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     const numSiblingsPerParagraphNode = [];
     for (const fnode of paragraphFnodes) {
       const {element} = fnode;
@@ -718,8 +717,8 @@ class ArticleRuleset {
     return Math.round(sum / numSiblingsPerParagraphNode.length) >= 3; // Optimized with 40 training samples
   }
 
-  mostParagraphElementsAreHorizontallyAligned(fnode) {
-    const paragraphFnodes = this.highestScoringParagraphs || this.getHighestScoringParagraphs(fnode);
+  function mostParagraphElementsAreHorizontallyAligned(fnode) {
+    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     const leftPositionVsFrequency = new Map();
     for (const {element} of paragraphFnodes) {
       const left = element.getBoundingClientRect().left;
@@ -740,8 +739,8 @@ class ArticleRuleset {
     return sum >= 9; // Optimized with 40 training samples
   }
 
-  moreParagraphElementsThanListItemsOrTableRows(fnode) {
-    const paragraphFnodes = this.highestScoringParagraphs || this.getHighestScoringParagraphs(fnode);
+  function moreParagraphElementsThanListItemsOrTableRows(fnode) {
+    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     const numParagraphElements = paragraphFnodes.length;
     const tableRowElements = fnode.element.ownerDocument.getElementsByTagName("tr");
     const listItemElements = fnode.element.ownerDocument.getElementsByTagName("li");
@@ -750,10 +749,10 @@ class ArticleRuleset {
     return numParagraphElements > tableRowElements.length && numParagraphElements > listItemElements.length;
   }
 
-  headerElementIsSiblingToParagraphElements(fnode) {
+  function headerElementIsSiblingToParagraphElements(fnode) {
     const headerTagNames = ["H1", "H2"];
     let counter = 0;
-    const paragraphFnodes = this.highestScoringParagraphs || this.getHighestScoringParagraphs(fnode);
+    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     for (const {element} of paragraphFnodes) {
       const siblings = Array.from(element.parentNode.children).filter(node => node !== element);
       if (siblings.some(sibling => headerTagNames.includes(sibling.tagName))) {
@@ -761,49 +760,45 @@ class ArticleRuleset {
       }
     }
     // TODO: Include paragraphs inside divs with brs, see 'getNumParagraphsInAllDivs'
-    const {utils: {linearScale}} = fathom;
     return linearScale(counter, 4, 11); // oneAt cut-off optimized with 40 samples
   }
 
-  makeRuleset() {
-    const {dom, rule, ruleset, score, type} = fathom;
-    return ruleset([
-        /**
-         * Paragraph rules
-         */
-        // Consider all visible paragraph-ish elements
-        rule(dom("p, pre, div").when(this.isElementVisible).when(this.divHasBrChildElement.bind(this)), type("paragraph").note(this.numParagraphTextNodesInDiv)),
-        rule(type("paragraph"), score(this.pElementHasNoListItemAncestor.bind(this)), {name: "pElementHasNoListItemAncestor"}),
-        rule(type("paragraph"), score(this.hasLongTextContent.bind(this)), {name: "hasLongTextContent"}),
-        // return paragraph-ish element(s) with max score
-        rule(type("paragraph").max(), "paragraph"),
+  return ruleset([
+      /**
+       * Paragraph rules
+       */
+      // Consider all visible paragraph-ish elements
+      rule(dom("p, pre, div").when(isElementVisible).when(divHasBrChildElement), type("paragraph").note(numParagraphTextNodesInDiv)),
+      rule(type("paragraph"), score(pElementHasNoListItemAncestor), {name: "pElementHasNoListItemAncestor"}),
+      rule(type("paragraph"), score(hasLongTextContent), {name: "hasLongTextContent"}),
+      // return paragraph-ish element(s) with max score
+      rule(type("paragraph").max(), "paragraph"),
 
-        /**
-         * Article rules
-         */
-        rule(dom("html"), type("article")),
-        rule(type("article"), score(this.hasEnoughParagraphs.bind(this)), {name: "hasEnoughParagraphs"}),
-        rule(type("article"), score(this.hasArticleElement.bind(this)), {name: "hasArticleElement"}),
-        rule(type("article"), score(this.paragraphElementsHaveSiblingsWithSameTagName.bind(this)), {name: "paragraphElementsHaveSiblingsWithSameTagName"}),
-        rule(type("article"), score(this.mostParagraphElementsAreHorizontallyAligned.bind(this)), {name: "mostParagraphElementsAreHorizontallyAligned"}),
-        rule(type("article"), score(this.moreParagraphElementsThanListItemsOrTableRows.bind(this)), {name: "moreParagraphElementsThanListItemsOrTableRows"}),
-        rule(type("article"), score(this.headerElementIsSiblingToParagraphElements.bind(this)), {name: "headerElementIsSiblingToParagraphElements"}),
-        rule(type("article"), "article")
-      ],
-      [
-        ["pElementHasNoListItemAncestor", 1.9143790006637573],
-        ["hasLongTextContent", 2.991241216659546],
-        ["hasEnoughParagraphs", -6.825904369354248],
-        ["hasArticleElement", 0.5530931353569031],
-        ["paragraphElementsHaveSiblingsWithSameTagName", 5.291628837585449],
-        ["mostParagraphElementsAreHorizontallyAligned", 6.951136589050293],
-        ["moreParagraphElementsThanListItemsOrTableRows", 0.8062509894371033],
-        ["headerElementIsSiblingToParagraphElements", 9.11874008178711]
-      ],
-      [
-        ["paragraph", -3.526047468185425],
-        ["article", -3.6415750980377197]
-      ]
-    );
-  }
+      /**
+       * Article rules
+       */
+      rule(dom("html"), type("article")),
+      rule(type("article"), score(hasEnoughParagraphs), {name: "hasEnoughParagraphs"}),
+      rule(type("article"), score(hasArticleElement), {name: "hasArticleElement"}),
+      rule(type("article"), score(paragraphElementsHaveSiblingsWithSameTagName), {name: "paragraphElementsHaveSiblingsWithSameTagName"}),
+      rule(type("article"), score(mostParagraphElementsAreHorizontallyAligned), {name: "mostParagraphElementsAreHorizontallyAligned"}),
+      rule(type("article"), score(moreParagraphElementsThanListItemsOrTableRows), {name: "moreParagraphElementsThanListItemsOrTableRows"}),
+      rule(type("article"), score(headerElementIsSiblingToParagraphElements), {name: "headerElementIsSiblingToParagraphElements"}),
+      rule(type("article"), "article")
+    ],
+    [
+      ["pElementHasNoListItemAncestor", 1.9143790006637573],
+      ["hasLongTextContent", 2.991241216659546],
+      ["hasEnoughParagraphs", -6.825904369354248],
+      ["hasArticleElement", 0.5530931353569031],
+      ["paragraphElementsHaveSiblingsWithSameTagName", 5.291628837585449],
+      ["mostParagraphElementsAreHorizontallyAligned", 6.951136589050293],
+      ["moreParagraphElementsThanListItemsOrTableRows", 0.8062509894371033],
+      ["headerElementIsSiblingToParagraphElements", 9.11874008178711]
+    ],
+    [
+      ["paragraph", -3.526047468185425],
+      ["article", -3.6415750980377197]
+    ]
+  );
 }


### PR DESCRIPTION
This PR adds both the Shopping and Article rulesets to `FathomChild.jsm`. Now when `executeFathom()` runs, a new ruleset is made for each ruleset and they are run against the page. If the highest score is above 0.5, a color-coded border is placed around the page and a label is added stating which type the page is identified as being and the confidence of that assertion.