### PR TITLE
Update article ruleset to v25.

### DIFF
--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -85,7 +85,7 @@ class FathomChild extends JSWindowActorChild {
 
     const borderElement = this.document.createElement("DIV");
     borderElement.style.position = "fixed";
-    borderElement.style.zIndex = "1000";
+    borderElement.style.zIndex = "10000000";
     borderElement.style["pointer-events"] = "none";
     borderElement.style.top = "0";
     borderElement.style.bottom = "0";

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -38,9 +38,14 @@ class FathomChild extends JSWindowActorChild {
   executeFathom() {
     const shoppingRules = makeShoppingRuleset();
     const articleRules = makeArticleRuleset();
+    const shoppingFnodes = shoppingRules.against(this.document).get("shopping");
+    const articleFnodes = articleRules.against(this.document).get("article");
+    // Fathom may not have found any candidate nodes, so handle this case:
+    const shoppingScore = shoppingFnodes.length === 0 ? 0 : shoppingFnodes[0].scoreFor("shopping");
+    const articleScore = articleFnodes.length === 0 ? 0 : articleFnodes[0].scoreFor("article");
     const scores = {
-      "shopping": shoppingRules.against(this.document).get("shopping")[0].scoreFor("shopping"),
-      "article": articleRules.against(this.document).get("article")[0].scoreFor("article")
+      "shopping": shoppingScore,
+      "article": articleScore,
     };
     console.log("shopping: ", scores["shopping"]);
     console.log("article: ", scores["article"]);

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -673,26 +673,63 @@ function makeArticleRuleset() {
   let highestScoringParagraphs;
   let numParagraphsInAllDivs;
 
-  // Text nodes are not targetable via document.querySelectorAll (i.e. Fathom's `dom` method).
-  // We instead use a heuristic to estimate the number of paragraph-like text nodes based on the
-  // number of descendant <br> elements and list elements in the <div>
+  const MIN_PARAGRAPH_LENGTH = 234; // Optimized with 10 sample pages
+  const UNLIKELY_WORDS_IN_PARAGRAPH_CLASSNAMES = /comment|caption/i
+
+  // Text nodes are not targetable via document.querySelectorAll (i.e. Fathom's `dom` method), so we instead use
+  // different heuristics based on the child elements contained inside the <div>.
   function numParagraphTextNodesInDiv({element}) {
-    if (element.tagName !== "DIV") {
-      return 0;
+    if (divHasBrChildElement({element})) {
+      // Estimate the number of paragraph-like text nodes based on the number of descendant <br> elements and
+      // list elements in the <div>
+      const listDescendants = Array.from(element.querySelectorAll("ol")).concat(Array.from(element.querySelectorAll("ul")));
+      const brDescendants = Array.from(element.querySelectorAll("br"));
+      const pDescendants = Array.from(element.querySelectorAll("p"));
+      // We assume a <br> divides two text nodes/"chunks" (a paragraph or a list)
+      // But let's make sure each <br> is actually immediately adjacent to at least one textNode of sufficient length, as
+      // sometimes there are lots of extra <br>s just for styling purposes.
+      const brsNextToSufficientlyLongTextNodes = brDescendants.filter((descendant) => {
+        const {previousSibling, nextSibling} = descendant;
+        if (previousSibling && previousSibling.nodeType === Node.TEXT_NODE && previousSibling.length >= MIN_PARAGRAPH_LENGTH) {
+          return true;
+        }
+        if (nextSibling && nextSibling.nodeType === Node.TEXT_NODE && nextSibling.length >= MIN_PARAGRAPH_LENGTH) {
+          return true;
+        }
+        return false;
+      });
+      return (brsNextToSufficientlyLongTextNodes.length - listDescendants.length - pDescendants.length + 1);
     }
-    const listDescendants = Array.from(element.querySelectorAll("ol")).concat(Array.from(element.querySelectorAll("ul")));
-    const brDescendants = Array.from(element.querySelectorAll("br"));
-    // We assume a <br> divides two text nodes/"chunks" (a paragraph or a list)
-    return (brDescendants.length - listDescendants.length + 1);
+    // The only other divs this function would receive are if divHasOnlyTextNodesAnchorElementsOrSpanElements,
+    // so we'll just say the div contains one paragraph if its text nodes, when summed together, have sufficient length.
+    const textNodeLengths = Array.from(element.childNodes).map(node => node.nodeType === Node.TEXT_NODE ? node.nodeValue.length : 0);
+    const totalLength = textNodeLengths.reduce((prev, current) => current + prev, 0);
+    return (totalLength >= MIN_PARAGRAPH_LENGTH) ? 1 : 0;
   }
 
-  function getNumParagraphsInAllDivs(paragraphFnodes) {
-    const divWithBrFnodes = paragraphFnodes.filter(({element}) => element.tagName === "DIV");
-    return divWithBrFnodes.reduce((accumulator, currentValue) => {
+  function getNumParagraphsInAllDivs(highestScoringParagraphs) {
+    const divFnodes = highestScoringParagraphs.filter(({element}) => element.tagName === "DIV");
+    return divFnodes.reduce((accumulator, currentValue) => {
       return accumulator + currentValue.noteFor("paragraph");
     }, 0);
   }
 
+  // Returns true if an element's center coordinates are somewhere likely to be the main content area of the page.
+  function elementIsInTheMainContentArea(element) {
+    const {left, top, width, height} = element.getBoundingClientRect();
+    const [xCenter, yCenter] = [left + (width / 2), top + (height / 2)];
+    // Get the middle 50% area of the page in the x-direction (TODO: Optimize %).
+    const win = element.ownerDocument.defaultView;
+    const docLeftCutoff = win.innerWidth / 4;
+    const docRightCutoff = 3 * win.innerWidth / 4;
+    const MAIN_CONTENT_VERTICAL_CUTOFF = 200; // TODO Optimize
+    return (xCenter >= docLeftCutoff && xCenter <= docRightCutoff && yCenter >= MAIN_CONTENT_VERTICAL_CUTOFF);
+  }
+
+
+  /**
+  * Positive ``when`` callbacks
+  */
   function isElementVisible({element}) {
     // Have to null-check element.style to deal with SVG and MathML nodes.
     return (
@@ -701,40 +738,81 @@ function makeArticleRuleset() {
     );
   }
 
+  function divHasOnlyTextNodesAnchorElementsOrSpanElements({element}) {
+    return Array.from(element.childNodes).every(node => (node.nodeType === Node.TEXT_NODE || node.tagName === "A" || node.tagName === "SPAN"));
+  }
+
   function divHasBrChildElement({element}) {
-    if (element.tagName !== "DIV") {
-      return true;
-    }
     return Array.from(element.children).some((childEle) => childEle.tagName === "BR");
   }
 
-  function pElementHasNoListItemAncestor({element}) {
-    return !element.matches("li p");
+  /**
+  * Negative "paragraph" rules
+  */
+  function pElementHasListItemAncestor({element}) {
+    return element.matches("li p");
   }
 
+  // This probably means this is just a preview of a complete paragraph
+  function containsElipsisAtEndOfText({element}) {
+    return element.innerText.endsWith("...");
+  }
+
+  // Modeled after toolkit/components/reader/Readability-readerable.js in Firefox
+  function classNameOfSelfOrParentContainsUnlikelyWord({element}) {
+    const matchString = `${element.className} ${element.parentNode.className}`;
+    return UNLIKELY_WORDS_IN_PARAGRAPH_CLASSNAMES.test(matchString);
+  }
+
+  /**
+  * Positive "paragraph" rules
+  */
   function hasLongTextContent({element}) {
     const textContentLength = element.textContent.trim().length;
-    return textContentLength >= 234; // Optimized with 10 sample pages; see /vectors/rule_output_analysis.ipynb
+    return linearScale(textContentLength, 0, MIN_PARAGRAPH_LENGTH);
   }
 
   function getHighestScoringParagraphs(fnode) {
     return fnode._ruleset.get("paragraph");
   }
 
-  function hasEnoughParagraphs(fnode) {
-    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
-    const paragraphsInDivsWithBrs = numParagraphsInAllDivs || getNumParagraphsInAllDivs(paragraphFnodes);
-    return (paragraphFnodes.length + paragraphsInDivsWithBrs) >= 9; // Optimized with 40 training samples
+  /**
+  * Negative "article rules"
+  */
+  // Often homepages of news websites have article previews (i.e. not a single, encapsulated article).
+  function hasMultipleArticleElements({element}) {
+    const doc = element.ownerDocument;
+    const articleElements = doc.querySelectorAll("article");
+    return articleElements.length > 1;
   }
 
-  function hasArticleElement(fnode) {
-    return !!(fnode.element.ownerDocument.querySelector("article"));
+  function hasMultipleParagraphsWhoseClassNameIncludesArticle(fnode) {
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    const paragraphsWithArticleInClassName = highestScoringParagraphs.filter(({element}) => element.className.toLowerCase().includes("article"));
+    return paragraphsWithArticleInClassName.length > 1;
+
+  }
+
+  /**
+  * Positive "article" rules
+  */
+  function hasEnoughParagraphs(fnode) {
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    numParagraphsInAllDivs = numParagraphsInAllDivs || getNumParagraphsInAllDivs(highestScoringParagraphs);
+    return (highestScoringParagraphs.length + numParagraphsInAllDivs) >= 9; // Optimized with 40 training samples
+  }
+
+  function hasExactlyOneArticleElement({element}) {
+    const doc = element.ownerDocument;
+    const articleElements = doc.querySelectorAll("article");
+    // TODO: May want to award less points the more article elements a page has. Revisit.
+    return articleElements.length === 1;
   }
 
   function paragraphElementsHaveSiblingsWithSameTagName(fnode) {
-    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     const numSiblingsPerParagraphNode = [];
-    for (const fnode of paragraphFnodes) {
+    for (const fnode of highestScoringParagraphs) {
       const {element} = fnode;
       let siblingsWithSameTagName = 0;
       if (element.tagName === "DIV") {
@@ -749,15 +827,16 @@ function makeArticleRuleset() {
       }
       numSiblingsPerParagraphNode.push(siblingsWithSameTagName);
     }
-    const sum = numSiblingsPerParagraphNode.reduce((prev, current) => current += prev, 0);
+    const sum = numSiblingsPerParagraphNode.reduce((prev, current) => current + prev, 0);
     // average sibling count per highest scoring paragraph node; divide by 0 returns NaN which makes the feature return false
     return Math.round(sum / numSiblingsPerParagraphNode.length) >= 3; // Optimized with 40 training samples
   }
 
   function mostParagraphElementsAreHorizontallyAligned(fnode) {
-    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    // TODO: Include paragraphs inside divs with brs, see 'getNumParagraphsInAllDivs'
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
     const leftPositionVsFrequency = new Map();
-    for (const {element} of paragraphFnodes) {
+    for (const {element} of highestScoringParagraphs) {
       const left = element.getBoundingClientRect().left;
       if (leftPositionVsFrequency.get(left) === undefined) {
         leftPositionVsFrequency.set(left, 1);
@@ -766,21 +845,27 @@ function makeArticleRuleset() {
       }
     }
 
-    // At least one left position should contain the majority of paragraph nodes
-    const totals = [];
+    const totals = []; // Each element (int) corresponds to the number of paragraphs with the same left position
     for (const total of leftPositionVsFrequency.values()) {
       totals.push(total);
     }
-    const sum = totals.reduce((prev, current) => current += prev, 0);
-    // TODO: Include paragraphs inside divs with brs, see 'getNumParagraphsInAllDivs'
-    return sum >= 9; // Optimized with 40 training samples
+
+    const maxNumParagraphsWithSameLeftPosition = Math.max(...totals);
+    if (highestScoringParagraphs.length < 2) {
+      // Avoid divide by 0 errors, and we don't want to give a page that only has one paragraph the max score;
+      // this rule is intended to compare a paragraph's left position relative to other paragraphs.
+      return 0;
+    }
+
+    return maxNumParagraphsWithSameLeftPosition / highestScoringParagraphs.length;
   }
 
   function moreParagraphElementsThanListItemsOrTableRows(fnode) {
-    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
-    const numParagraphElements = paragraphFnodes.length;
-    const tableRowElements = fnode.element.ownerDocument.getElementsByTagName("tr");
-    const listItemElements = fnode.element.ownerDocument.getElementsByTagName("li");
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    const numParagraphElements = highestScoringParagraphs.length;
+    const doc = fnode.element.ownerDocument;
+    const tableRowElements = Array.from(doc.querySelectorAll("tr")).filter(node => elementIsInTheMainContentArea(node));
+    const listItemElements = Array.from(doc.getElementsByTagName("li")).filter(node => elementIsInTheMainContentArea(node));
     // TODO: Include paragraphs inside divs with brs, see 'getNumParagraphsInAllDivs'
     // TODO: the greater the difference, the higher the score
     return numParagraphElements > tableRowElements.length && numParagraphElements > listItemElements.length;
@@ -789,8 +874,8 @@ function makeArticleRuleset() {
   function headerElementIsSiblingToParagraphElements(fnode) {
     const headerTagNames = ["H1", "H2"];
     let counter = 0;
-    const paragraphFnodes = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
-    for (const {element} of paragraphFnodes) {
+    highestScoringParagraphs = highestScoringParagraphs || getHighestScoringParagraphs(fnode);
+    for (const {element} of highestScoringParagraphs) {
       const siblings = Array.from(element.parentNode.children).filter(node => node !== element);
       if (siblings.some(sibling => headerTagNames.includes(sibling.tagName))) {
         counter++;
@@ -800,14 +885,19 @@ function makeArticleRuleset() {
     return linearScale(counter, 4, 11); // oneAt cut-off optimized with 40 samples
   }
 
-  return ruleset([
+  return ruleset(
+    [
       /**
        * Paragraph rules
        */
       // Consider all visible paragraph-ish elements
-      rule(dom("p, pre, div").when(isElementVisible).when(divHasBrChildElement), type("paragraph").note(numParagraphTextNodesInDiv)),
-      rule(type("paragraph"), score(pElementHasNoListItemAncestor), {name: "pElementHasNoListItemAncestor"}),
+      rule(dom("p, pre").when(isElementVisible), type("paragraph")),
+      rule(dom("div").when(isElementVisible).when(divHasBrChildElement), type("paragraph").note(numParagraphTextNodesInDiv)),
+      rule(dom("div").when(isElementVisible).when(divHasOnlyTextNodesAnchorElementsOrSpanElements), type("paragraph").note(numParagraphTextNodesInDiv)),
+      rule(type("paragraph"), score(pElementHasListItemAncestor), {name: "pElementHasListItemAncestor"}),
       rule(type("paragraph"), score(hasLongTextContent), {name: "hasLongTextContent"}),
+      rule(type("paragraph"), score(containsElipsisAtEndOfText), {name: "containsElipsisAtEndOfText"}),
+      rule(type("paragraph"), score(classNameOfSelfOrParentContainsUnlikelyWord), {name: "classNameOfSelfOrParentContainsUnlikelyWord"}),
       // return paragraph-ish element(s) with max score
       rule(type("paragraph").max(), "paragraph"),
 
@@ -816,26 +906,28 @@ function makeArticleRuleset() {
        */
       rule(dom("html"), type("article")),
       rule(type("article"), score(hasEnoughParagraphs), {name: "hasEnoughParagraphs"}),
-      rule(type("article"), score(hasArticleElement), {name: "hasArticleElement"}),
+      rule(type("article"), score(hasExactlyOneArticleElement), {name: "hasExactlyOneArticleElement"}),
       rule(type("article"), score(paragraphElementsHaveSiblingsWithSameTagName), {name: "paragraphElementsHaveSiblingsWithSameTagName"}),
       rule(type("article"), score(mostParagraphElementsAreHorizontallyAligned), {name: "mostParagraphElementsAreHorizontallyAligned"}),
       rule(type("article"), score(moreParagraphElementsThanListItemsOrTableRows), {name: "moreParagraphElementsThanListItemsOrTableRows"}),
       rule(type("article"), score(headerElementIsSiblingToParagraphElements), {name: "headerElementIsSiblingToParagraphElements"}),
+      rule(type("article"), score(hasMultipleArticleElements), {name: "hasMultipleArticleElements"}),
+      rule(type("article"), score(hasMultipleParagraphsWhoseClassNameIncludesArticle), {name: "hasMultipleParagraphsWhoseClassNameIncludesArticle"}),
       rule(type("article"), "article")
     ],
     [
-      ["pElementHasNoListItemAncestor", 1.9143790006637573],
-      ["hasLongTextContent", 2.991241216659546],
-      ["hasEnoughParagraphs", -6.825904369354248],
-      ["hasArticleElement", 0.5530931353569031],
-      ["paragraphElementsHaveSiblingsWithSameTagName", 5.291628837585449],
-      ["mostParagraphElementsAreHorizontallyAligned", 6.951136589050293],
-      ["moreParagraphElementsThanListItemsOrTableRows", 0.8062509894371033],
-      ["headerElementIsSiblingToParagraphElements", 9.11874008178711]
+      ["hasEnoughParagraphs", -1.0311405658721924],
+      ["hasExactlyOneArticleElement", -1.2359271049499512],
+      ["paragraphElementsHaveSiblingsWithSameTagName", 12.159211158752441],
+      ["mostParagraphElementsAreHorizontallyAligned", 0.5681423544883728],
+      ["moreParagraphElementsThanListItemsOrTableRows", -2.6533799171447754],
+      ["headerElementIsSiblingToParagraphElements", 12.294110298156738],
+      ["hasMultipleArticleElements", -3.300487756729126],
+      ["hasMultipleParagraphsWhoseClassNameIncludesArticle", 0.26676997542381287]
     ],
     [
-      ["paragraph", -3.526047468185425],
-      ["article", -3.6415750980377197]
+      ["paragraph", -4.550228595733643],
+      ["article", -2.676619291305542]
     ]
   );
 }

--- a/browser/actors/FathomChild.jsm
+++ b/browser/actors/FathomChild.jsm
@@ -679,7 +679,7 @@ function makeArticleRuleset() {
   let numParagraphsInAllDivs;
 
   const MIN_PARAGRAPH_LENGTH = 234; // Optimized with 10 sample pages
-  const UNLIKELY_WORDS_IN_PARAGRAPH_CLASSNAMES = /comment|caption/i
+  const UNLIKELY_WORDS_IN_PARAGRAPH_CLASSNAMES = /comment|caption/i;
 
   // Text nodes are not targetable via document.querySelectorAll (i.e. Fathom's `dom` method), so we instead use
   // different heuristics based on the child elements contained inside the <div>.
@@ -921,6 +921,10 @@ function makeArticleRuleset() {
       rule(type("article"), "article")
     ],
     [
+      ["pElementHasListItemAncestor", -2.86763596534729],
+      ["hasLongTextContent", 5.575725555419922],
+      ["containsElipsisAtEndOfText", -0.13708636164665222],
+      ["classNameOfSelfOrParentContainsUnlikelyWord", -2.073239326477051],
       ["hasEnoughParagraphs", -1.0311405658721924],
       ["hasExactlyOneArticleElement", -1.2359271049499512],
       ["paragraphElementsHaveSiblingsWithSameTagName", 12.159211158752441],


### PR DESCRIPTION
Edit: Turns out I just had a transcription error in copying my ruleset over into the demo -- I was missing some paragraph rule coefficients.

--

Unfortunately, I am not seeing the 9/10 kind of performance I would expect when randomly visiting pages given my [test accuracy per tag of 93%](https://github.com/mozilla-services/fathom-smoot/commit/25047c6569a4480625579eff32dba4e257ba75e2)[1].

This indicates to me that the random collection of samples Vlad put together is not necessarily representative.

I could try:
* These same pages on `smoot-demo` (without the revised ruleset). Does it perform better?
* These pages in mozilla-services/fathom-smoot (outside of the Smoot demo project) with my current article v25 ruleset and see if they have the same confidences.

[1]:
Some example sites that are failing consistently:
  * Fast Company:
    * 0%: https://www.fastcompany.com/90452018/climate-change-wont-result-in-a-new-normal-but-in-constant-horrifying-new-disasters
  * Wikipedia
    * 6%: https://en.wikipedia.org/wiki/Banana
    * 100%: https://en.wikipedia.org/wiki/Trousers
    * 6%: https://en.wikipedia.org/wiki/Elephant
  * Npr.org
    * 0%: https://www.npr.org/2020/01/16/796994699/aussie-firefighters-save-worlds-only-groves-of-prehistoric-wollemi-pines
    * 0%: https://www.npr.org/2020/01/16/796328145/electric-burn-those-who-bet-against-elon-musk-and-tesla-are-paying-a-big-price
    * 0%: https://www.npr.org/sections/health-shots/2020/01/16/796316186/scientists-sent-mighty-mice-to-space-to-improve-treatments-back-on-earth
  * Cnn.com
    * 0%: https://www.cnn.com/2020/01/16/politics/pompeo-state-department-silence-new-evidence/index.html
    * 0%: https://www.cnn.com/2020/01/16/politics/saudi-arabia-us-troops-payment/index.html
    * 0%: https://www.cnn.com/2020/01/15/tech/ai-job-interview/index.html